### PR TITLE
CHM T001: Scaffold FastAPI service skeleton

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,2 @@
+"""CHM application package."""
+

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,2 @@
+"""API routers package for CHM."""
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,11 @@
+"""FastAPI application entrypoint for CHM."""
+
+from fastapi import FastAPI
+
+app = FastAPI(title="CHM")
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Health check stub endpoint for service readiness."""
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
Implements T001 by scaffolding the FastAPI service skeleton.

## Changes
- Add app/main.py with FastAPI app entrypoint.
- Add GET /health route stub.
- Add package init files: app/__init__.py, app/api/__init__.py.

## DoD Checklist
- [x] App package imports cleanly
- [x] Health route stub exists
- [x] Changes restricted to T001 paths

## Acceptance Check
- Ran: `.venv/bin/python -c "import app.main"` (pass)

## Base Branch
- Targeting `main`
