### PR TITLE
CHM T003: Add local Postgres Grafana Metabase stack

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,57 @@
+services:
+  postgres:
+    image: postgres:15
+    container_name: chm-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: chm
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d chm"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  grafana:
+    image: grafana/grafana-oss:11.1.0
+    container_name: chm-grafana
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+    volumes:
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  metabase:
+    image: metabase/metabase:v0.55.8
+    container_name: chm-metabase
+    restart: unless-stopped
+    ports:
+      - "3001:3000"
+    environment:
+      MB_DB_TYPE: postgres
+      MB_DB_DBNAME: chm
+      MB_DB_PORT: 5432
+      MB_DB_USER: postgres
+      MB_DB_PASS: postgres
+      MB_DB_HOST: postgres
+    volumes:
+      - metabase_data:/metabase-data
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  postgres_data:
+  grafana_data:
+  metabase_data:


### PR DESCRIPTION
## Summary
Implements T003 local dependency stack for CHM development.

## Changes
- Add docker/docker-compose.yml with:
  - Postgres 15 (`5432:5432`)
  - Grafana OSS (`3000:3000`)
  - Metabase (`3001:3000`)
- Include named persistent volumes and service health/dependency wiring.

## DoD Checklist
- [x] Compose file defines Postgres, Grafana, and Metabase
- [x] Stable host ports are configured
- [x] Configuration validates successfully

## Acceptance Check
- Ran: `docker compose -f docker/docker-compose.yml config` (pass)

## Base Branch
- Targeting `main`
