### PR TITLE
CHM T005: Add GitHub issue and PR templates for task workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/chm-task.md
+++ b/.github/ISSUE_TEMPLATE/chm-task.md
@@ -1,0 +1,21 @@
+---
+name: CHM Task
+about: Track one SpecKit task as one GitHub issue
+title: "CHM TXXX: "
+labels: ["task"]
+assignees: []
+---
+
+## Task Reference
+- Task ID: `TXXX`
+- Source: `specs/001-chm-api-ingestion/tasks.md`
+
+## Scope
+Describe the exact scope for this single task.
+
+## Definition of Done
+- [ ] Task implementation completed per SpecKit task text
+- [ ] Acceptance check command executed and passing
+
+## Links
+- Related PR: <!-- add PR link -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary
+Describe the single task implemented in this PR.
+
+## Task Link
+Closes #<issue-number>
+
+## Checklist
+- [ ] This PR implements exactly one primary task
+- [ ] Base branch is `main`
+- [ ] Acceptance check command(s) executed locally
+- [ ] No requirements added beyond spec/contracts


### PR DESCRIPTION
## Summary
Implements T005 by adding task-focused GitHub issue and PR templates.

## Changes
- Add `.github/ISSUE_TEMPLATE/chm-task.md`
- Add `.github/pull_request_template.md`
- Templates include issue linkage and base branch `main` checklist item.

## DoD Checklist
- [x] Issue template exists at required path
- [x] PR template exists at required path
- [x] Template content supports issue-per-task and `main` targeting workflow

## Acceptance Check
- Ran: `test -f .github/ISSUE_TEMPLATE/chm-task.md && test -f .github/pull_request_template.md` (pass)

## Base Branch
- Targeting `main`
