### PR TITLE
CHM T006: Create enum types migration

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,38 @@
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+sqlalchemy.url = postgresql+psycopg://postgres:postgres@127.0.0.1:5432/chm
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+database_url = os.getenv("CHM_DATABASE_URL")
+if database_url:
+    config.set_main_option("sqlalchemy.url", database_url)
+
+target_metadata = None
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/versions/001_create_enums.py
+++ b/migrations/versions/001_create_enums.py
@@ -1,0 +1,73 @@
+"""Create enum types used by CHM domain tables."""
+
+from typing import Sequence
+from typing import Union
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "001_create_enums"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+platform_enum = postgresql.ENUM(
+    "airflow",
+    "dbt",
+    "cron",
+    "vendor_api",
+    "custom",
+    name="platform",
+)
+
+pipeline_type_enum = postgresql.ENUM(
+    "ingestion",
+    "transform",
+    "quality",
+    "export",
+    "healthcheck",
+    name="pipeline_type",
+)
+
+run_status_enum = postgresql.ENUM(
+    "running",
+    "success",
+    "failed",
+    "canceled",
+    "skipped",
+    name="run_status",
+)
+
+rule_type_enum = postgresql.ENUM(
+    "on_failure",
+    "failures_in_window",
+    name="rule_type",
+)
+
+channel_enum = postgresql.ENUM(
+    "slack",
+    "email",
+    "webhook",
+    name="channel",
+)
+
+
+def upgrade() -> None:
+    """Create all enum types before dependent tables are introduced."""
+    bind = op.get_bind()
+    platform_enum.create(bind, checkfirst=True)
+    pipeline_type_enum.create(bind, checkfirst=True)
+    run_status_enum.create(bind, checkfirst=True)
+    rule_type_enum.create(bind, checkfirst=True)
+    channel_enum.create(bind, checkfirst=True)
+
+
+def downgrade() -> None:
+    """Drop enum types in reverse dependency-safe order."""
+    bind = op.get_bind()
+    channel_enum.drop(bind, checkfirst=True)
+    rule_type_enum.drop(bind, checkfirst=True)
+    run_status_enum.drop(bind, checkfirst=True)
+    pipeline_type_enum.drop(bind, checkfirst=True)
+    platform_enum.drop(bind, checkfirst=True)


### PR DESCRIPTION
## Summary
Implements T006 by adding enum migration for CHM categorical fields.

## Changes
- Add `migrations/versions/001_create_enums.py` to create/drop:
  - `platform`
  - `pipeline_type`
  - `run_status`
  - `rule_type`
  - `channel`
- Add minimal Alembic runtime files needed to execute migration checks in this repo:
  - `alembic.ini`
  - `migrations/env.py`

## DoD Checklist
- [x] Enum migration file created at required path
- [x] Enum values match spec/contracts
- [x] Migration applies and rolls back cleanly

## Acceptance Check
- Ran: `.venv/bin/alembic upgrade +1 && .venv/bin/alembic downgrade -1` (pass)

## Base Branch
- Targeting `main`
