### PR TITLE
CHM T007: Add clients and pipelines schema migration

### DIFF
--- a/migrations/versions/002_clients_pipelines.py
+++ b/migrations/versions/002_clients_pipelines.py
@@ -1,0 +1,98 @@
+"""Add clients and pipelines tables with FK and uniqueness constraints."""
+
+from typing import Sequence
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "002_clients_pipelines"
+down_revision: Union[str, None] = "001_create_enums"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create core inventory tables for clients and pipelines."""
+    platform_enum = postgresql.ENUM(name="platform", create_type=False)
+    pipeline_type_enum = postgresql.ENUM(name="pipeline_type", create_type=False)
+
+    op.create_table(
+        "clients",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_clients"),
+        sa.UniqueConstraint("name", name="uq_clients_name"),
+    )
+
+    op.create_table(
+        "pipelines",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("client_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("platform", platform_enum, nullable=False),
+        sa.Column("external_id", sa.String(length=255), nullable=True),
+        sa.Column("pipeline_type", pipeline_type_enum, nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "environment",
+            sa.String(length=16),
+            nullable=False,
+            server_default=sa.text("'prod'"),
+        ),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint(
+            "environment IN ('dev', 'staging', 'prod')",
+            name="ck_pipelines_environment",
+        ),
+        sa.ForeignKeyConstraint(
+            ["client_id"],
+            ["clients.id"],
+            name="fk_pipelines_client_id_clients",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_pipelines"),
+        sa.UniqueConstraint("client_id", "name", name="uq_pipelines_client_id_name"),
+    )
+
+    op.create_index(
+        "uq_pipelines_client_platform_external_id",
+        "pipelines",
+        ["client_id", "platform", "external_id"],
+        unique=True,
+        postgresql_where=sa.text("external_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Drop core inventory tables for clients and pipelines."""
+    op.drop_index("uq_pipelines_client_platform_external_id", table_name="pipelines")
+    op.drop_table("pipelines")
+    op.drop_table("clients")


### PR DESCRIPTION
## Summary
Implements T007 by adding clients/pipelines schema migration with FK and uniqueness constraints.

## Changes
- Added `migrations/versions/002_clients_pipelines.py`
- Created `clients` table with:
  - primary key `id`
  - unique `name`
  - `is_active`, `created_at`, `updated_at`
- Created `pipelines` table with:
  - primary key `id`
  - foreign key `client_id -> clients.id` (restrict delete)
  - unique `(client_id, name)`
  - enum-backed `platform` and `pipeline_type`
  - environment check constraint and defaults/audit fields
  - unique partial index on `(client_id, platform, external_id)` when `external_id IS NOT NULL`

## DoD Checklist
- [x] Clients and pipelines tables created
- [x] `(client_id, name)` uniqueness enforced
- [x] FK behavior from `pipelines.client_id` to `clients.id` enforced

## Acceptance Checks
- Task-defined command: `.venv/bin/pytest tests/integration/test_schema_constraints.py -k clients_pipelines`
  - Result: file not found (`tests/integration/test_schema_constraints.py` is not present yet)
- Migration smoke executed:
  - `.venv/bin/alembic upgrade head && .venv/bin/alembic downgrade -1` (pass)

## Base Branch
- Targeting `main`
