### PR TITLE
CHM T010: Implement SQLAlchemy models for CHM entities

### DIFF
--- a/app/db/models/alert_rule.py
+++ b/app/db/models/alert_rule.py
@@ -1,0 +1,110 @@
+"""SQLAlchemy model for CHM alert rules."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean
+from sqlalchemy import CheckConstraint
+from sqlalchemy import DateTime
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import PrimaryKeyConstraint
+from sqlalchemy import String
+from sqlalchemy import text
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import mapped_column
+from sqlalchemy.orm import relationship
+
+from app.db.models.client import Base
+
+
+class RuleTypeEnum(str, Enum):
+    ON_FAILURE = "on_failure"
+    FAILURES_IN_WINDOW = "failures_in_window"
+
+
+class ChannelEnum(str, Enum):
+    SLACK = "slack"
+    EMAIL = "email"
+    WEBHOOK = "webhook"
+
+
+if TYPE_CHECKING:
+    from app.db.models.client import Client
+    from app.db.models.pipeline import Pipeline
+
+
+class AlertRule(Base):
+    """Rule definition for alerting scope and thresholds."""
+
+    __tablename__ = "alert_rules"
+    __table_args__ = (
+        PrimaryKeyConstraint("id", name="pk_alert_rules"),
+        CheckConstraint(
+            "client_id IS NOT NULL OR pipeline_id IS NOT NULL",
+            name="ck_alert_rules_scope_required",
+        ),
+        CheckConstraint(
+            "threshold IS NULL OR threshold > 0",
+            name="ck_alert_rules_threshold_positive",
+        ),
+        CheckConstraint(
+            "window_minutes IS NULL OR window_minutes > 0",
+            name="ck_alert_rules_window_minutes_positive",
+        ),
+        CheckConstraint(
+            "(rule_type = 'on_failure' OR (rule_type = 'failures_in_window' AND threshold IS NOT NULL AND window_minutes IS NOT NULL))",
+            name="ck_alert_rules_rule_type_params",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    client_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("clients.id", name="fk_alert_rules_client_id_clients", ondelete="RESTRICT"),
+        nullable=True,
+    )
+    pipeline_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("pipelines.id", name="fk_alert_rules_pipeline_id_pipelines", ondelete="RESTRICT"),
+        nullable=True,
+    )
+    rule_type: Mapped[RuleTypeEnum] = mapped_column(
+        postgresql.ENUM(RuleTypeEnum, name="rule_type", create_type=False),
+        nullable=False,
+    )
+    threshold: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    window_minutes: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    channel: Mapped[ChannelEnum] = mapped_column(
+        postgresql.ENUM(ChannelEnum, name="channel", create_type=False),
+        nullable=False,
+    )
+    destination: Mapped[str] = mapped_column(String(512), nullable=False)
+    is_enabled: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=text("true"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+
+    client: Mapped["Client | None"] = relationship("Client", back_populates="alert_rules")
+    pipeline: Mapped["Pipeline | None"] = relationship("Pipeline", back_populates="alert_rules")

--- a/app/db/models/client.py
+++ b/app/db/models/client.py
@@ -1,0 +1,63 @@
+"""SQLAlchemy model for CHM clients."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean
+from sqlalchemy import DateTime
+from sqlalchemy import PrimaryKeyConstraint
+from sqlalchemy import String
+from sqlalchemy import UniqueConstraint
+from sqlalchemy import text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import mapped_column
+from sqlalchemy.orm import relationship
+
+
+class Base(DeclarativeBase):
+    """Declarative base for CHM ORM models."""
+
+
+if TYPE_CHECKING:
+    from app.db.models.alert_rule import AlertRule
+    from app.db.models.pipeline import Pipeline
+
+
+class Client(Base):
+    """Client inventory entity."""
+
+    __tablename__ = "clients"
+    __table_args__ = (
+        PrimaryKeyConstraint("id", name="pk_clients"),
+        UniqueConstraint("name", name="uq_clients_name"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    is_active: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=text("true"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+
+    pipelines: Mapped[list["Pipeline"]] = relationship("Pipeline", back_populates="client")
+    alert_rules: Mapped[list["AlertRule"]] = relationship("AlertRule", back_populates="client")

--- a/app/db/models/pipeline.py
+++ b/app/db/models/pipeline.py
@@ -1,0 +1,116 @@
+"""SQLAlchemy model for CHM pipelines."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean
+from sqlalchemy import CheckConstraint
+from sqlalchemy import DateTime
+from sqlalchemy import ForeignKey
+from sqlalchemy import Index
+from sqlalchemy import PrimaryKeyConstraint
+from sqlalchemy import String
+from sqlalchemy import Text
+from sqlalchemy import UniqueConstraint
+from sqlalchemy import text
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import mapped_column
+from sqlalchemy.orm import relationship
+
+from app.db.models.client import Base
+
+
+class PlatformEnum(str, Enum):
+    AIRFLOW = "airflow"
+    DBT = "dbt"
+    CRON = "cron"
+    VENDOR_API = "vendor_api"
+    CUSTOM = "custom"
+
+
+class PipelineTypeEnum(str, Enum):
+    INGESTION = "ingestion"
+    TRANSFORM = "transform"
+    QUALITY = "quality"
+    EXPORT = "export"
+    HEALTHCHECK = "healthcheck"
+
+
+if TYPE_CHECKING:
+    from app.db.models.alert_rule import AlertRule
+    from app.db.models.client import Client
+    from app.db.models.run import Run
+
+
+class Pipeline(Base):
+    """Pipeline inventory entity under a client."""
+
+    __tablename__ = "pipelines"
+    __table_args__ = (
+        PrimaryKeyConstraint("id", name="pk_pipelines"),
+        UniqueConstraint("client_id", "name", name="uq_pipelines_client_id_name"),
+        CheckConstraint(
+            "environment IN ('dev', 'staging', 'prod')",
+            name="ck_pipelines_environment",
+        ),
+        Index(
+            "uq_pipelines_client_platform_external_id",
+            "client_id",
+            "platform",
+            "external_id",
+            unique=True,
+            postgresql_where=text("external_id IS NOT NULL"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    client_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("clients.id", name="fk_pipelines_client_id_clients", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    platform: Mapped[PlatformEnum] = mapped_column(
+        postgresql.ENUM(PlatformEnum, name="platform", create_type=False),
+        nullable=False,
+    )
+    external_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    pipeline_type: Mapped[PipelineTypeEnum] = mapped_column(
+        postgresql.ENUM(PipelineTypeEnum, name="pipeline_type", create_type=False),
+        nullable=False,
+    )
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    environment: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        server_default=text("'prod'"),
+    )
+    is_active: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=text("true"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+
+    client: Mapped["Client"] = relationship("Client", back_populates="pipelines")
+    runs: Mapped[list["Run"]] = relationship("Run", back_populates="pipeline")
+    alert_rules: Mapped[list["AlertRule"]] = relationship("AlertRule", back_populates="pipeline")

--- a/app/db/models/run.py
+++ b/app/db/models/run.py
@@ -1,0 +1,100 @@
+"""SQLAlchemy model for CHM pipeline runs."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from sqlalchemy import BigInteger
+from sqlalchemy import CheckConstraint
+from sqlalchemy import DateTime
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import PrimaryKeyConstraint
+from sqlalchemy import Text
+from sqlalchemy import UniqueConstraint
+from sqlalchemy import text
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import mapped_column
+from sqlalchemy.orm import relationship
+
+from app.db.models.client import Base
+
+
+class RunStatusEnum(str, Enum):
+    RUNNING = "running"
+    SUCCESS = "success"
+    FAILED = "failed"
+    CANCELED = "canceled"
+    SKIPPED = "skipped"
+
+
+if TYPE_CHECKING:
+    from app.db.models.pipeline import Pipeline
+
+
+class Run(Base):
+    """Execution record for a pipeline run."""
+
+    __tablename__ = "runs"
+    __table_args__ = (
+        PrimaryKeyConstraint("id", name="pk_runs"),
+        UniqueConstraint(
+            "pipeline_id",
+            "external_run_id",
+            name="uq_runs_pipeline_id_external_run_id",
+        ),
+        CheckConstraint(
+            "duration_seconds IS NULL OR duration_seconds >= 0",
+            name="ck_runs_duration_non_negative",
+        ),
+        CheckConstraint(
+            "rows_processed IS NULL OR rows_processed >= 0",
+            name="ck_runs_rows_processed_non_negative",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    pipeline_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("pipelines.id", name="fk_runs_pipeline_id_pipelines", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    external_run_id: Mapped[str] = mapped_column(postgresql.VARCHAR(255), nullable=False)
+    status: Mapped[RunStatusEnum] = mapped_column(
+        postgresql.ENUM(RunStatusEnum, name="run_status", create_type=False),
+        nullable=False,
+    )
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    duration_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    rows_processed: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    payload: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    ingested_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+
+    pipeline: Mapped["Pipeline"] = relationship("Pipeline", back_populates="runs")


### PR DESCRIPTION
## Summary
Implements T010 SQLAlchemy models for the four-table CHM domain.

## Changes
- Added `app/db/models/client.py`
- Added `app/db/models/pipeline.py`
- Added `app/db/models/run.py`
- Added `app/db/models/alert_rule.py`

Models include:
- Table names aligned with migrations (`clients`, `pipelines`, `runs`, `alert_rules`)
- Named constraints/FKs matching migration identifiers
- PostgreSQL enum mappings for platform/pipeline_type/run_status/rule_type/channel
- Cross-entity relationships (`Client`->`Pipeline`, `Pipeline`->`Run`, `AlertRule` scopes)

## DoD Checklist
- [x] SQLAlchemy models implemented for all four entities
- [x] ORM metadata includes schema constraints and relationships aligned to migrations
- [x] Model modules import cleanly

## Acceptance Checks
- Task-defined command: `.venv/bin/pytest tests/unit/test_model_metadata.py`
  - Result: file not found (`tests/unit/test_model_metadata.py` not present yet)
- Supplemental verification executed:
  - `.venv/bin/python` import smoke for all model modules (pass)
  - Metadata table presence check for `clients`, `pipelines`, `runs`, `alert_rules` (pass)
  - Constraint name inspection against migration naming (pass)

## Base Branch
- Targeting `main`
