### PR TITLE
CHM T011: Implement repository layer foundation

### DIFF
--- a/app/db/base.py
+++ b/app/db/base.py
@@ -1,0 +1,51 @@
+"""Database engine and session helpers for CHM."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+import os
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
+
+DEFAULT_DATABASE_URL = "postgresql+psycopg://postgres:postgres@127.0.0.1:5432/chm"
+
+DATABASE_URL = os.getenv("CHM_DATABASE_URL", DEFAULT_DATABASE_URL)
+
+engine = create_engine(
+    DATABASE_URL,
+    pool_pre_ping=True,
+)
+
+SessionLocal = sessionmaker(
+    bind=engine,
+    autoflush=False,
+    autocommit=False,
+    expire_on_commit=False,
+    class_=Session,
+)
+
+
+def get_db_session() -> Generator[Session, None, None]:
+    """Yield a database session for dependency injection."""
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@contextmanager
+def session_scope() -> Generator[Session, None, None]:
+    """Provide a transactional session scope for scripts/tests."""
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/app/db/models/alert_rule.py
+++ b/app/db/models/alert_rule.py
@@ -80,13 +80,23 @@ class AlertRule(Base):
         nullable=True,
     )
     rule_type: Mapped[RuleTypeEnum] = mapped_column(
-        postgresql.ENUM(RuleTypeEnum, name="rule_type", create_type=False),
+        postgresql.ENUM(
+            RuleTypeEnum,
+            name="rule_type",
+            values_callable=lambda enum_cls: [member.value for member in enum_cls],
+            create_type=False,
+        ),
         nullable=False,
     )
     threshold: Mapped[int | None] = mapped_column(Integer, nullable=True)
     window_minutes: Mapped[int | None] = mapped_column(Integer, nullable=True)
     channel: Mapped[ChannelEnum] = mapped_column(
-        postgresql.ENUM(ChannelEnum, name="channel", create_type=False),
+        postgresql.ENUM(
+            ChannelEnum,
+            name="channel",
+            values_callable=lambda enum_cls: [member.value for member in enum_cls],
+            create_type=False,
+        ),
         nullable=False,
     )
     destination: Mapped[str] = mapped_column(String(512), nullable=False)

--- a/app/db/models/pipeline.py
+++ b/app/db/models/pipeline.py
@@ -81,12 +81,22 @@ class Pipeline(Base):
     )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     platform: Mapped[PlatformEnum] = mapped_column(
-        postgresql.ENUM(PlatformEnum, name="platform", create_type=False),
+        postgresql.ENUM(
+            PlatformEnum,
+            name="platform",
+            values_callable=lambda enum_cls: [member.value for member in enum_cls],
+            create_type=False,
+        ),
         nullable=False,
     )
     external_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     pipeline_type: Mapped[PipelineTypeEnum] = mapped_column(
-        postgresql.ENUM(PipelineTypeEnum, name="pipeline_type", create_type=False),
+        postgresql.ENUM(
+            PipelineTypeEnum,
+            name="pipeline_type",
+            values_callable=lambda enum_cls: [member.value for member in enum_cls],
+            create_type=False,
+        ),
         nullable=False,
     )
     description: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/app/db/models/run.py
+++ b/app/db/models/run.py
@@ -71,7 +71,12 @@ class Run(Base):
     )
     external_run_id: Mapped[str] = mapped_column(postgresql.VARCHAR(255), nullable=False)
     status: Mapped[RunStatusEnum] = mapped_column(
-        postgresql.ENUM(RunStatusEnum, name="run_status", create_type=False),
+        postgresql.ENUM(
+            RunStatusEnum,
+            name="run_status",
+            values_callable=lambda enum_cls: [member.value for member in enum_cls],
+            create_type=False,
+        ),
         nullable=False,
     )
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/app/db/repository/alert_rules.py
+++ b/app/db/repository/alert_rules.py
@@ -1,0 +1,114 @@
+"""Repository primitives for alert-rule entities."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.models.alert_rule import AlertRule
+from app.db.models.alert_rule import ChannelEnum
+from app.db.models.alert_rule import RuleTypeEnum
+
+
+def create_alert_rule(
+    session: Session,
+    *,
+    rule_type: RuleTypeEnum,
+    channel: ChannelEnum,
+    destination: str,
+    client_id: UUID | None = None,
+    pipeline_id: UUID | None = None,
+    threshold: int | None = None,
+    window_minutes: int | None = None,
+    is_enabled: bool = True,
+) -> AlertRule:
+    """Create and return an alert rule row."""
+    rule_type_value = rule_type.value if isinstance(rule_type, RuleTypeEnum) else rule_type
+    channel_value = channel.value if isinstance(channel, ChannelEnum) else channel
+
+    alert_rule = AlertRule(
+        client_id=client_id,
+        pipeline_id=pipeline_id,
+        rule_type=rule_type_value,
+        threshold=threshold,
+        window_minutes=window_minutes,
+        channel=channel_value,
+        destination=destination,
+        is_enabled=is_enabled,
+    )
+    session.add(alert_rule)
+    session.flush()
+    session.refresh(alert_rule)
+    return alert_rule
+
+
+def get_alert_rule(session: Session, rule_id: UUID) -> AlertRule | None:
+    """Fetch an alert rule by id."""
+    return session.get(AlertRule, rule_id)
+
+
+def list_alert_rules(
+    session: Session,
+    *,
+    client_id: UUID | None = None,
+    pipeline_id: UUID | None = None,
+    is_enabled: bool | None = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> list[AlertRule]:
+    """List alert rules with optional scope/enablement filters."""
+    stmt = select(AlertRule)
+    if client_id is not None:
+        stmt = stmt.where(AlertRule.client_id == client_id)
+    if pipeline_id is not None:
+        stmt = stmt.where(AlertRule.pipeline_id == pipeline_id)
+    if is_enabled is not None:
+        stmt = stmt.where(AlertRule.is_enabled == is_enabled)
+    stmt = stmt.order_by(AlertRule.created_at.desc()).limit(limit).offset(offset)
+    return list(session.scalars(stmt))
+
+
+def update_alert_rule(
+    session: Session,
+    alert_rule: AlertRule,
+    *,
+    rule_type: RuleTypeEnum | None = None,
+    channel: ChannelEnum | None = None,
+    destination: str | None = None,
+    client_id: UUID | None = None,
+    pipeline_id: UUID | None = None,
+    threshold: int | None = None,
+    window_minutes: int | None = None,
+    is_enabled: bool | None = None,
+) -> AlertRule:
+    """Update mutable alert-rule fields."""
+    if rule_type is not None:
+        alert_rule.rule_type = (
+            rule_type.value if isinstance(rule_type, RuleTypeEnum) else rule_type
+        )
+    if channel is not None:
+        alert_rule.channel = channel.value if isinstance(channel, ChannelEnum) else channel
+    if destination is not None:
+        alert_rule.destination = destination
+    if client_id is not None:
+        alert_rule.client_id = client_id
+    if pipeline_id is not None:
+        alert_rule.pipeline_id = pipeline_id
+    if threshold is not None:
+        alert_rule.threshold = threshold
+    if window_minutes is not None:
+        alert_rule.window_minutes = window_minutes
+    if is_enabled is not None:
+        alert_rule.is_enabled = is_enabled
+
+    session.flush()
+    session.refresh(alert_rule)
+    return alert_rule
+
+
+def delete_alert_rule(session: Session, alert_rule: AlertRule) -> None:
+    """Delete an alert-rule row."""
+    session.delete(alert_rule)
+    session.flush()

--- a/app/db/repository/clients.py
+++ b/app/db/repository/clients.py
@@ -1,0 +1,64 @@
+"""Repository primitives for client entities."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.models.client import Client
+
+
+def create_client(session: Session, *, name: str, is_active: bool = True) -> Client:
+    """Create and return a client row."""
+    client = Client(name=name, is_active=is_active)
+    session.add(client)
+    session.flush()
+    session.refresh(client)
+    return client
+
+
+def get_client(session: Session, client_id: UUID) -> Client | None:
+    """Fetch a client by id."""
+    return session.get(Client, client_id)
+
+
+def list_clients(
+    session: Session,
+    *,
+    is_active: bool | None = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> list[Client]:
+    """List clients with optional active-state filtering."""
+    stmt = select(Client)
+    if is_active is not None:
+        stmt = stmt.where(Client.is_active == is_active)
+    stmt = stmt.order_by(Client.created_at.desc()).limit(limit).offset(offset)
+    return list(session.scalars(stmt))
+
+
+def update_client(
+    session: Session,
+    client: Client,
+    *,
+    name: str | None = None,
+    is_active: bool | None = None,
+) -> Client:
+    """Update mutable client fields."""
+    if name is not None:
+        client.name = name
+    if is_active is not None:
+        client.is_active = is_active
+    session.flush()
+    session.refresh(client)
+    return client
+
+
+def disable_client(session: Session, client: Client) -> Client:
+    """Soft-disable a client."""
+    client.is_active = False
+    session.flush()
+    session.refresh(client)
+    return client

--- a/app/db/repository/pipelines.py
+++ b/app/db/repository/pipelines.py
@@ -1,0 +1,115 @@
+"""Repository primitives for pipeline entities."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.models.pipeline import Pipeline
+from app.db.models.pipeline import PipelineTypeEnum
+from app.db.models.pipeline import PlatformEnum
+
+
+def create_pipeline(
+    session: Session,
+    *,
+    client_id: UUID,
+    name: str,
+    platform: PlatformEnum,
+    pipeline_type: PipelineTypeEnum,
+    external_id: str | None = None,
+    description: str | None = None,
+    environment: str = "prod",
+    is_active: bool = True,
+) -> Pipeline:
+    """Create and return a pipeline row."""
+    platform_value = platform.value if isinstance(platform, PlatformEnum) else platform
+    pipeline_type_value = (
+        pipeline_type.value if isinstance(pipeline_type, PipelineTypeEnum) else pipeline_type
+    )
+
+    pipeline = Pipeline(
+        client_id=client_id,
+        name=name,
+        platform=platform_value,
+        pipeline_type=pipeline_type_value,
+        external_id=external_id,
+        description=description,
+        environment=environment,
+        is_active=is_active,
+    )
+    session.add(pipeline)
+    session.flush()
+    session.refresh(pipeline)
+    return pipeline
+
+
+def get_pipeline(session: Session, pipeline_id: UUID) -> Pipeline | None:
+    """Fetch a pipeline by id."""
+    return session.get(Pipeline, pipeline_id)
+
+
+def list_pipelines(
+    session: Session,
+    *,
+    client_id: UUID | None = None,
+    is_active: bool | None = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> list[Pipeline]:
+    """List pipelines with optional client/active filters."""
+    stmt = select(Pipeline)
+    if client_id is not None:
+        stmt = stmt.where(Pipeline.client_id == client_id)
+    if is_active is not None:
+        stmt = stmt.where(Pipeline.is_active == is_active)
+    stmt = stmt.order_by(Pipeline.created_at.desc()).limit(limit).offset(offset)
+    return list(session.scalars(stmt))
+
+
+def update_pipeline(
+    session: Session,
+    pipeline: Pipeline,
+    *,
+    name: str | None = None,
+    platform: PlatformEnum | None = None,
+    pipeline_type: PipelineTypeEnum | None = None,
+    external_id: str | None = None,
+    description: str | None = None,
+    environment: str | None = None,
+    is_active: bool | None = None,
+) -> Pipeline:
+    """Update mutable pipeline fields."""
+    if name is not None:
+        pipeline.name = name
+    if platform is not None:
+        pipeline.platform = platform.value if isinstance(platform, PlatformEnum) else platform
+    if pipeline_type is not None:
+        pipeline.pipeline_type = (
+            pipeline_type.value
+            if isinstance(pipeline_type, PipelineTypeEnum)
+            else pipeline_type
+        )
+    if description is not None:
+        pipeline.description = description
+    if environment is not None:
+        pipeline.environment = environment
+    if is_active is not None:
+        pipeline.is_active = is_active
+
+    if external_id is not None:
+        pipeline.external_id = external_id
+
+    session.flush()
+    session.refresh(pipeline)
+    return pipeline
+
+
+def disable_pipeline(session: Session, pipeline: Pipeline) -> Pipeline:
+    """Soft-disable a pipeline."""
+    pipeline.is_active = False
+    session.flush()
+    session.refresh(pipeline)
+    return pipeline

--- a/app/db/repository/runs.py
+++ b/app/db/repository/runs.py
@@ -1,0 +1,142 @@
+"""Repository primitives for pipeline run entities."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import Select
+from sqlalchemy import desc
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.models.run import Run
+from app.db.models.run import RunStatusEnum
+
+
+def create_run(
+    session: Session,
+    *,
+    pipeline_id: UUID,
+    external_run_id: str,
+    status: RunStatusEnum,
+    started_at: datetime | None = None,
+    finished_at: datetime | None = None,
+    duration_seconds: int | None = None,
+    rows_processed: int | None = None,
+    error_message: str | None = None,
+    status_reason: str | None = None,
+    payload: dict | None = None,
+) -> Run:
+    """Create and return a run row."""
+    status_value = status.value if isinstance(status, RunStatusEnum) else status
+
+    run = Run(
+        pipeline_id=pipeline_id,
+        external_run_id=external_run_id,
+        status=status_value,
+        started_at=started_at,
+        finished_at=finished_at,
+        duration_seconds=duration_seconds,
+        rows_processed=rows_processed,
+        error_message=error_message,
+        status_reason=status_reason,
+        payload=payload,
+    )
+    session.add(run)
+    session.flush()
+    session.refresh(run)
+    return run
+
+
+def get_run(session: Session, run_id: UUID) -> Run | None:
+    """Fetch a run by id."""
+    return session.get(Run, run_id)
+
+
+def list_runs(
+    session: Session,
+    *,
+    pipeline_id: UUID,
+    status: RunStatusEnum | None = None,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    limit: int = 100,
+    order: str = "desc",
+) -> list[Run]:
+    """List runs for a pipeline with optional filters."""
+    stmt: Select[tuple[Run]] = select(Run).where(Run.pipeline_id == pipeline_id)
+    if status is not None:
+        status_value = status.value if isinstance(status, RunStatusEnum) else status
+        stmt = stmt.where(Run.status == status_value)
+    if since is not None:
+        stmt = stmt.where(Run.started_at >= since)
+    if until is not None:
+        stmt = stmt.where(Run.started_at < until)
+
+    if order == "asc":
+        stmt = stmt.order_by(
+            Run.started_at.asc().nulls_last(),
+            Run.finished_at.asc().nulls_last(),
+            Run.id.asc(),
+        )
+    else:
+        stmt = stmt.order_by(
+            Run.started_at.desc().nulls_last(),
+            Run.finished_at.desc().nulls_last(),
+            Run.id.desc(),
+        )
+
+    stmt = stmt.limit(limit)
+    return list(session.scalars(stmt))
+
+
+def get_latest_run_for_pipeline(session: Session, *, pipeline_id: UUID) -> Run | None:
+    """Return the latest run for a pipeline using CHM ordering rules."""
+    stmt = (
+        select(Run)
+        .where(Run.pipeline_id == pipeline_id)
+        .order_by(
+            Run.started_at.desc().nulls_last(),
+            Run.finished_at.desc().nulls_last(),
+            desc(Run.id),
+        )
+        .limit(1)
+    )
+    return session.scalars(stmt).first()
+
+
+def update_run(
+    session: Session,
+    run: Run,
+    *,
+    status: RunStatusEnum | None = None,
+    started_at: datetime | None = None,
+    finished_at: datetime | None = None,
+    duration_seconds: int | None = None,
+    rows_processed: int | None = None,
+    error_message: str | None = None,
+    status_reason: str | None = None,
+    payload: dict | None = None,
+) -> Run:
+    """Update mutable run fields."""
+    if status is not None:
+        run.status = status.value if isinstance(status, RunStatusEnum) else status
+    if started_at is not None:
+        run.started_at = started_at
+    if finished_at is not None:
+        run.finished_at = finished_at
+    if duration_seconds is not None:
+        run.duration_seconds = duration_seconds
+    if rows_processed is not None:
+        run.rows_processed = rows_processed
+    if error_message is not None:
+        run.error_message = error_message
+    if status_reason is not None:
+        run.status_reason = status_reason
+    if payload is not None:
+        run.payload = payload
+
+    session.flush()
+    session.refresh(run)
+    return run


### PR DESCRIPTION
## Summary
Implements T011 repository foundation and DB session utilities.

## Changes
- Added `app/db/base.py`
  - Engine/session factory (`SessionLocal`)
  - `get_db_session()` dependency generator
  - `session_scope()` transactional context manager
- Added repository modules:
  - `app/db/repository/clients.py`
  - `app/db/repository/pipelines.py`
  - `app/db/repository/runs.py`
  - `app/db/repository/alert_rules.py`
- Added CRUD-style repository primitives (create/get/list/update/disable/delete where applicable).

## Required Compatibility Fix
To make repository CRUD work with existing Postgres enum types, this task also includes a targeted ORM mapping fix:
- Updated enum column mappings in:
  - `app/db/models/pipeline.py`
  - `app/db/models/run.py`
  - `app/db/models/alert_rule.py`
- Applied `values_callable` so ORM writes canonical lowercase enum values (`airflow`, `running`, etc.) instead of enum member names (`AIRFLOW`, `RUNNING`).

## DoD Checklist
- [x] DB session/base helpers implemented
- [x] Repository foundation implemented for clients, pipelines, runs, alert rules
- [x] CRUD primitives validated via smoke workflow

## Acceptance Checks
- Task-defined command: `.venv/bin/pytest tests/unit/test_repositories_smoke.py`
  - Result: file not found (`tests/unit/test_repositories_smoke.py` not present yet)
- Supplemental verification:
  - Repository import smoke (pass)
  - `docker compose -f docker/docker-compose.yml up -d postgres` (pass)
  - `.venv/bin/alembic upgrade head` (pass)
  - Repository CRUD smoke script using `session_scope` and all 4 repositories (pass)

## Base Branch
- Targeting `main`
