### PR TITLE
CHM T015: Implement consistent API error envelope

### DIFF
--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core application utilities and configuration."""

--- a/app/core/errors.py
+++ b/app/core/errors.py
@@ -1,0 +1,185 @@
+"""API error envelope and exception handler registration."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi import Request
+from fastapi import status
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from app.schemas.error import ErrorDetail
+from app.schemas.error import ErrorObject
+from app.schemas.error import ErrorResponse
+
+
+class APIError(Exception):
+    """Base application exception for explicit API error responses."""
+
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        code: str,
+        message: str,
+        details: Sequence[ErrorDetail] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+        self.details = list(details) if details else None
+
+
+class NotFoundError(APIError):
+    """Convenience exception for missing resources."""
+
+    def __init__(self, *, message: str = "Resource not found") -> None:
+        super().__init__(status_code=status.HTTP_404_NOT_FOUND, code="not_found", message=message)
+
+
+def _build_error_response(
+    *,
+    status_code: int,
+    code: str,
+    message: str,
+    details: Sequence[ErrorDetail] | None = None,
+) -> JSONResponse:
+    payload = ErrorResponse(error=ErrorObject(code=code, message=message, details=list(details) if details else None))
+    return JSONResponse(status_code=status_code, content=payload.model_dump(exclude_none=True))
+
+
+def _http_error_code(status_code: int) -> str:
+    if status_code == status.HTTP_404_NOT_FOUND:
+        return "not_found"
+    if status_code == status.HTTP_400_BAD_REQUEST:
+        return "validation_error"
+    if status_code == status.HTTP_401_UNAUTHORIZED:
+        return "unauthorized"
+    if status_code == status.HTTP_403_FORBIDDEN:
+        return "forbidden"
+    if status_code == status.HTTP_409_CONFLICT:
+        return "conflict"
+    if status_code >= status.HTTP_500_INTERNAL_SERVER_ERROR:
+        return "internal_error"
+    return "bad_request"
+
+
+def _validation_details(exc: RequestValidationError) -> list[ErrorDetail]:
+    details: list[ErrorDetail] = []
+    for issue in exc.errors():
+        location = issue.get("loc", ())
+        field = _format_location(location)
+        message = str(issue.get("msg", "Invalid value"))
+        details.append(ErrorDetail(field=field, issue=message))
+    return details
+
+
+def _format_location(location: tuple[Any, ...] | list[Any] | Any) -> str:
+    if not isinstance(location, (tuple, list)):
+        return str(location)
+
+    prefixes = {"body", "query", "path", "header", "cookie"}
+    filtered = [str(part) for part in location if part not in prefixes]
+    if filtered:
+        return ".".join(filtered)
+
+    if not location:
+        return "request"
+
+    return str(location[0])
+
+
+async def request_validation_exception_handler(_: Request, exc: RequestValidationError) -> JSONResponse:
+    """Normalize FastAPI validation errors to the CHM error envelope."""
+
+    return _build_error_response(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        code="validation_error",
+        message="Request validation failed",
+        details=_validation_details(exc),
+    )
+
+
+async def http_exception_handler(_: Request, exc: StarletteHTTPException) -> JSONResponse:
+    """Normalize HTTP exceptions to the CHM error envelope."""
+
+    details: Sequence[ErrorDetail] | None = None
+
+    if isinstance(exc.detail, dict):
+        detail = exc.detail
+        if "error" in detail and isinstance(detail["error"], dict):
+            error = detail["error"]
+            code = str(error.get("code", _http_error_code(exc.status_code)))
+            message = str(error.get("message", "Request failed"))
+            raw_details = error.get("details")
+            if isinstance(raw_details, list):
+                details = [
+                    ErrorDetail(field=str(item.get("field", "request")), issue=str(item.get("issue", "Invalid value")))
+                    for item in raw_details
+                    if isinstance(item, dict)
+                ]
+            return _build_error_response(
+                status_code=exc.status_code,
+                code=code,
+                message=message,
+                details=details,
+            )
+
+        if "code" in detail and "message" in detail:
+            code = str(detail.get("code"))
+            message = str(detail.get("message"))
+            raw_details = detail.get("details")
+            if isinstance(raw_details, list):
+                details = [
+                    ErrorDetail(field=str(item.get("field", "request")), issue=str(item.get("issue", "Invalid value")))
+                    for item in raw_details
+                    if isinstance(item, dict)
+                ]
+            return _build_error_response(
+                status_code=exc.status_code,
+                code=code,
+                message=message,
+                details=details,
+            )
+
+    message = str(exc.detail) if isinstance(exc.detail, str) and exc.detail else "Request failed"
+    return _build_error_response(
+        status_code=exc.status_code,
+        code=_http_error_code(exc.status_code),
+        message=message,
+    )
+
+
+async def api_error_handler(_: Request, exc: APIError) -> JSONResponse:
+    """Return explicit domain errors in the shared envelope."""
+
+    return _build_error_response(
+        status_code=exc.status_code,
+        code=exc.code,
+        message=exc.message,
+        details=exc.details,
+    )
+
+
+async def unhandled_exception_handler(_: Request, __: Exception) -> JSONResponse:
+    """Avoid leaking internal exceptions while keeping response shape stable."""
+
+    return _build_error_response(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        code="internal_error",
+        message="Internal server error",
+    )
+
+
+def register_error_handlers(app: FastAPI) -> None:
+    """Attach all CHM error handlers to a FastAPI app instance."""
+
+    app.add_exception_handler(RequestValidationError, request_validation_exception_handler)
+    app.add_exception_handler(StarletteHTTPException, http_exception_handler)
+    app.add_exception_handler(APIError, api_error_handler)
+    app.add_exception_handler(Exception, unhandled_exception_handler)

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,10 @@
 
 from fastapi import FastAPI
 
+from app.core.errors import register_error_handlers
+
 app = FastAPI(title="CHM")
+register_error_handlers(app)
 
 
 @app.get("/health")

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Pydantic schema models for API contracts."""

--- a/app/schemas/error.py
+++ b/app/schemas/error.py
@@ -1,0 +1,26 @@
+"""Error envelope schemas shared across API handlers."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class ErrorDetail(BaseModel):
+    """Single field-level validation or domain issue detail."""
+
+    field: str
+    issue: str
+
+
+class ErrorObject(BaseModel):
+    """Canonical error payload object."""
+
+    code: str
+    message: str
+    details: list[ErrorDetail] | None = None
+
+
+class ErrorResponse(BaseModel):
+    """Top-level API error response envelope."""
+
+    error: ErrorObject

--- a/tests/unit/test_error_handlers.py
+++ b/tests/unit/test_error_handlers.py
@@ -1,0 +1,98 @@
+"""Unit tests for shared API error envelope handlers."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from app.core.errors import APIError
+from app.core.errors import NotFoundError
+from app.core.errors import register_error_handlers
+from app.schemas.error import ErrorDetail
+
+
+def _build_client() -> TestClient:
+    app = FastAPI()
+    register_error_handlers(app)
+
+    @app.get("/query")
+    def query(limit: int) -> dict[str, int]:
+        return {"limit": limit}
+
+    @app.get("/not-found")
+    def not_found() -> None:
+        raise NotFoundError(message="Pipeline not found")
+
+    @app.get("/domain")
+    def domain_error() -> None:
+        raise APIError(
+            status_code=400,
+            code="validation_error",
+            message="Invalid run payload",
+            details=[ErrorDetail(field="status", issue="Unsupported value")],
+        )
+
+    @app.get("/http")
+    def http_error() -> None:
+        raise StarletteHTTPException(status_code=404, detail="Client not found")
+
+    return TestClient(app)
+
+
+def test_request_validation_errors_are_normalized_to_envelope() -> None:
+    client = _build_client()
+
+    response = client.get("/query")
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload["error"]["code"] == "validation_error"
+    assert payload["error"]["message"] == "Request validation failed"
+    assert payload["error"]["details"][0]["field"] == "limit"
+
+
+def test_domain_errors_use_shared_envelope() -> None:
+    client = _build_client()
+
+    response = client.get("/domain")
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload == {
+        "error": {
+            "code": "validation_error",
+            "message": "Invalid run payload",
+            "details": [{"field": "status", "issue": "Unsupported value"}],
+        }
+    }
+
+
+def test_not_found_errors_use_shared_envelope() -> None:
+    client = _build_client()
+
+    response = client.get("/not-found")
+
+    assert response.status_code == 404
+    payload = response.json()
+    assert payload == {
+        "error": {
+            "code": "not_found",
+            "message": "Pipeline not found",
+        }
+    }
+
+
+def test_http_errors_are_wrapped_in_shared_envelope() -> None:
+    client = _build_client()
+
+    response = client.get("/http")
+
+    assert response.status_code == 404
+    payload = response.json()
+    assert payload == {
+        "error": {
+            "code": "not_found",
+            "message": "Client not found",
+        }
+    }


### PR DESCRIPTION
## Summary
- add shared error envelope schemas for `error.code`, `error.message`, and optional `error.details`
- add centralized FastAPI exception handlers for request validation, HTTP/domain, and unhandled errors
- register handlers in app startup and add focused unit tests for envelope behavior

## Task Link
Closes #18

## Verification
- `.venv/bin/pytest tests/unit/test_error_handlers.py -q`
- `.venv/bin/pytest tests/contract/test_clients_pipelines_runs_api.py -k error -q` *(currently fails because `T016`-`T019` routes are not implemented yet; handlers from this task are in place)*

## Checklist
- [x] This PR implements exactly one primary task
- [x] Base branch is `main`
- [x] Acceptance check command(s) executed locally
- [x] No requirements added beyond spec/contracts
