### PR TITLE
CHM T016: Implement clients API and service layer

### DIFF
--- a/app/api/clients.py
+++ b/app/api/clients.py
@@ -1,0 +1,71 @@
+"""Client API routes."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import Response
+from sqlalchemy.orm import Session
+
+from app.db.base import get_db_session
+from app.schemas.client import Client
+from app.schemas.client import ClientCreate
+from app.schemas.client import ClientListResponse
+from app.schemas.client import ClientUpdate
+from app.services.clients import create_client_service
+from app.services.clients import disable_client_service
+from app.services.clients import get_client_service
+from app.services.clients import list_clients_service
+from app.services.clients import update_client_service
+
+router = APIRouter(prefix="/api/v1", tags=["clients"])
+
+
+@router.post("/clients", response_model=Client, status_code=201)
+def create_client_endpoint(
+    payload: ClientCreate,
+    session: Session = Depends(get_db_session),
+) -> Client:
+    """Create a client."""
+    return create_client_service(session, payload)
+
+
+@router.get("/clients", response_model=ClientListResponse)
+def list_clients_endpoint(
+    is_active: bool | None = None,
+    session: Session = Depends(get_db_session),
+) -> ClientListResponse:
+    """List clients with optional active-state filter."""
+    clients = list_clients_service(session, is_active=is_active)
+    return ClientListResponse(items=clients)
+
+
+@router.get("/clients/{client_id}", response_model=Client)
+def get_client_endpoint(
+    client_id: UUID,
+    session: Session = Depends(get_db_session),
+) -> Client:
+    """Get a single client by id."""
+    return get_client_service(session, client_id)
+
+
+@router.patch("/clients/{client_id}", response_model=Client)
+def update_client_endpoint(
+    client_id: UUID,
+    payload: ClientUpdate,
+    session: Session = Depends(get_db_session),
+) -> Client:
+    """Update a client."""
+    return update_client_service(session, client_id, payload)
+
+
+@router.delete("/clients/{client_id}", status_code=204)
+def delete_client_endpoint(
+    client_id: UUID,
+    session: Session = Depends(get_db_session),
+) -> Response:
+    """Soft-disable a client."""
+    disable_client_service(session, client_id)
+    return Response(status_code=204)

--- a/app/db/models/__init__.py
+++ b/app/db/models/__init__.py
@@ -1,0 +1,13 @@
+"""Model module imports for SQLAlchemy relationship registration."""
+
+from app.db.models.alert_rule import AlertRule
+from app.db.models.client import Client
+from app.db.models.pipeline import Pipeline
+from app.db.models.run import Run
+
+__all__ = [
+    "AlertRule",
+    "Client",
+    "Pipeline",
+    "Run",
+]

--- a/app/main.py
+++ b/app/main.py
@@ -2,10 +2,13 @@
 
 from fastapi import FastAPI
 
+from app.api.clients import router as clients_router
 from app.core.errors import register_error_handlers
+from app.db import models as _models  # noqa: F401
 
 app = FastAPI(title="CHM")
 register_error_handlers(app)
+app.include_router(clients_router)
 
 
 @app.get("/health")

--- a/app/schemas/client.py
+++ b/app/schemas/client.py
@@ -1,0 +1,40 @@
+"""Pydantic schemas for client API payloads."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+
+
+class ClientCreate(BaseModel):
+    """Payload to create a client."""
+
+    name: str
+
+
+class ClientUpdate(BaseModel):
+    """Payload to update mutable client fields."""
+
+    name: str | None = None
+    is_active: bool | None = None
+
+
+class Client(BaseModel):
+    """Client response payload."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    name: str
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class ClientListResponse(BaseModel):
+    """List response envelope for clients."""
+
+    items: list[Client]

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer package for CHM."""

--- a/app/services/clients.py
+++ b/app/services/clients.py
@@ -1,0 +1,77 @@
+"""Service helpers for client API operations."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.errors import APIError
+from app.core.errors import NotFoundError
+from app.db.repository.clients import create_client
+from app.db.repository.clients import disable_client
+from app.db.repository.clients import get_client
+from app.db.repository.clients import list_clients
+from app.db.repository.clients import update_client
+from app.schemas.client import ClientCreate
+from app.schemas.client import ClientUpdate
+from app.schemas.error import ErrorDetail
+
+
+def _raise_validation_error(message: str, *, field: str = "request") -> None:
+    raise APIError(
+        status_code=400,
+        code="validation_error",
+        message=message,
+        details=[ErrorDetail(field=field, issue=message)],
+    )
+
+
+def create_client_service(session: Session, payload: ClientCreate):
+    """Create and persist a new client."""
+    try:
+        client = create_client(session, name=payload.name)
+        session.commit()
+        return client
+    except IntegrityError:
+        session.rollback()
+        _raise_validation_error("Client name must be unique", field="name")
+
+
+def list_clients_service(session: Session, *, is_active: bool | None = None):
+    """List clients with optional active-state filtering."""
+    return list_clients(session, is_active=is_active)
+
+
+def get_client_service(session: Session, client_id: UUID):
+    """Fetch a client or raise not found."""
+    client = get_client(session, client_id)
+    if client is None:
+        raise NotFoundError(message="Client not found")
+    return client
+
+
+def update_client_service(session: Session, client_id: UUID, payload: ClientUpdate):
+    """Update mutable client fields for an existing client."""
+    client = get_client_service(session, client_id)
+    try:
+        client = update_client(
+            session,
+            client,
+            name=payload.name,
+            is_active=payload.is_active,
+        )
+        session.commit()
+        return client
+    except IntegrityError:
+        session.rollback()
+        _raise_validation_error("Client name must be unique", field="name")
+
+
+def disable_client_service(session: Session, client_id: UUID):
+    """Soft-disable a client and persist the change."""
+    client = get_client_service(session, client_id)
+    client = disable_client(session, client)
+    session.commit()
+    return client


### PR DESCRIPTION
## Summary
- add client request/response schemas
- add client service layer with DB interactions and error translation
- add /api/v1/clients CRUD endpoints and wire router into app

## Acceptance
- ./.venv/bin/pytest tests/contract/test_clients_pipelines_runs_api.py -k clients -q (fails on pipeline/run endpoints not part of T016)
- ./.venv/bin/pytest tests/contract/test_clients_pipelines_runs_api.py::test_clients_crud_contract tests/contract/test_clients_pipelines_runs_api.py::test_clients_validation_error_contract -q
