### PR TITLE
CHM T017: Implement pipelines API and service layer

### DIFF
--- a/app/api/pipelines.py
+++ b/app/api/pipelines.py
@@ -1,0 +1,61 @@
+"""Pipeline API routes."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from app.db.base import get_db_session
+from app.schemas.pipeline import Pipeline
+from app.schemas.pipeline import PipelineCreate
+from app.schemas.pipeline import PipelineListResponse
+from app.schemas.pipeline import PipelineUpdate
+from app.services.pipelines import create_pipeline_service
+from app.services.pipelines import get_pipeline_service
+from app.services.pipelines import list_client_pipelines_service
+from app.services.pipelines import update_pipeline_service
+
+router = APIRouter(prefix="/api/v1", tags=["pipelines"])
+
+
+@router.post("/clients/{client_id}/pipelines", response_model=Pipeline, status_code=201)
+def create_pipeline_endpoint(
+    client_id: UUID,
+    payload: PipelineCreate,
+    session: Session = Depends(get_db_session),
+) -> Pipeline:
+    """Create a pipeline under a client."""
+    return create_pipeline_service(session, client_id, payload)
+
+
+@router.get("/clients/{client_id}/pipelines", response_model=PipelineListResponse)
+def list_client_pipelines_endpoint(
+    client_id: UUID,
+    is_active: bool | None = None,
+    session: Session = Depends(get_db_session),
+) -> PipelineListResponse:
+    """List pipelines for a client."""
+    pipelines = list_client_pipelines_service(session, client_id=client_id, is_active=is_active)
+    return PipelineListResponse(items=pipelines)
+
+
+@router.get("/pipelines/{pipeline_id}", response_model=Pipeline)
+def get_pipeline_endpoint(
+    pipeline_id: UUID,
+    session: Session = Depends(get_db_session),
+) -> Pipeline:
+    """Get a single pipeline by id."""
+    return get_pipeline_service(session, pipeline_id)
+
+
+@router.patch("/pipelines/{pipeline_id}", response_model=Pipeline)
+def update_pipeline_endpoint(
+    pipeline_id: UUID,
+    payload: PipelineUpdate,
+    session: Session = Depends(get_db_session),
+) -> Pipeline:
+    """Update a pipeline."""
+    return update_pipeline_service(session, pipeline_id, payload)

--- a/app/main.py
+++ b/app/main.py
@@ -3,12 +3,14 @@
 from fastapi import FastAPI
 
 from app.api.clients import router as clients_router
+from app.api.pipelines import router as pipelines_router
 from app.core.errors import register_error_handlers
 from app.db import models as _models  # noqa: F401
 
 app = FastAPI(title="CHM")
 register_error_handlers(app)
 app.include_router(clients_router)
+app.include_router(pipelines_router)
 
 
 @app.get("/health")

--- a/app/schemas/pipeline.py
+++ b/app/schemas/pipeline.py
@@ -1,0 +1,63 @@
+"""Pydantic schemas for pipeline API payloads."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+
+from app.db.models.pipeline import PipelineTypeEnum
+from app.db.models.pipeline import PlatformEnum
+
+Environment = Literal["dev", "staging", "prod"]
+
+
+class PipelineCreate(BaseModel):
+    """Payload to create a pipeline under a client."""
+
+    name: str
+    platform: PlatformEnum
+    pipeline_type: PipelineTypeEnum
+    external_id: str | None = None
+    description: str | None = None
+    environment: Environment = "prod"
+    is_active: bool = True
+
+
+class PipelineUpdate(BaseModel):
+    """Payload to update mutable pipeline fields."""
+
+    name: str | None = None
+    platform: PlatformEnum | None = None
+    pipeline_type: PipelineTypeEnum | None = None
+    external_id: str | None = None
+    description: str | None = None
+    environment: Environment | None = None
+    is_active: bool | None = None
+
+
+class Pipeline(BaseModel):
+    """Pipeline response payload."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    client_id: UUID
+    name: str
+    platform: PlatformEnum
+    external_id: str | None = None
+    pipeline_type: PipelineTypeEnum
+    description: str | None = None
+    environment: Environment
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class PipelineListResponse(BaseModel):
+    """List response envelope for pipelines."""
+
+    items: list[Pipeline]

--- a/app/services/pipelines.py
+++ b/app/services/pipelines.py
@@ -1,0 +1,96 @@
+"""Service helpers for pipeline API operations."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.errors import APIError
+from app.core.errors import NotFoundError
+from app.db.repository.clients import get_client
+from app.db.repository.pipelines import create_pipeline
+from app.db.repository.pipelines import get_pipeline
+from app.db.repository.pipelines import list_pipelines
+from app.db.repository.pipelines import update_pipeline
+from app.schemas.error import ErrorDetail
+from app.schemas.pipeline import PipelineCreate
+from app.schemas.pipeline import PipelineUpdate
+
+
+def _raise_validation_error(message: str, *, field: str = "request") -> None:
+    raise APIError(
+        status_code=400,
+        code="validation_error",
+        message=message,
+        details=[ErrorDetail(field=field, issue=message)],
+    )
+
+
+def _ensure_client_exists(session: Session, client_id: UUID) -> None:
+    if get_client(session, client_id) is None:
+        raise NotFoundError(message="Client not found")
+
+
+def create_pipeline_service(session: Session, client_id: UUID, payload: PipelineCreate):
+    """Create and persist a pipeline for a client."""
+    _ensure_client_exists(session, client_id)
+    try:
+        pipeline = create_pipeline(
+            session,
+            client_id=client_id,
+            name=payload.name,
+            platform=payload.platform,
+            pipeline_type=payload.pipeline_type,
+            external_id=payload.external_id,
+            description=payload.description,
+            environment=payload.environment,
+            is_active=payload.is_active,
+        )
+        session.commit()
+        return pipeline
+    except IntegrityError:
+        session.rollback()
+        _raise_validation_error("Pipeline payload violates schema constraints")
+
+
+def list_client_pipelines_service(
+    session: Session,
+    *,
+    client_id: UUID,
+    is_active: bool | None = None,
+):
+    """List pipelines scoped to a client."""
+    _ensure_client_exists(session, client_id)
+    return list_pipelines(session, client_id=client_id, is_active=is_active)
+
+
+def get_pipeline_service(session: Session, pipeline_id: UUID):
+    """Fetch a pipeline or raise not found."""
+    pipeline = get_pipeline(session, pipeline_id)
+    if pipeline is None:
+        raise NotFoundError(message="Pipeline not found")
+    return pipeline
+
+
+def update_pipeline_service(session: Session, pipeline_id: UUID, payload: PipelineUpdate):
+    """Update mutable pipeline fields for an existing pipeline."""
+    pipeline = get_pipeline_service(session, pipeline_id)
+    try:
+        pipeline = update_pipeline(
+            session,
+            pipeline,
+            name=payload.name,
+            platform=payload.platform,
+            pipeline_type=payload.pipeline_type,
+            external_id=payload.external_id,
+            description=payload.description,
+            environment=payload.environment,
+            is_active=payload.is_active,
+        )
+        session.commit()
+        return pipeline
+    except IntegrityError:
+        session.rollback()
+        _raise_validation_error("Pipeline payload violates schema constraints")


### PR DESCRIPTION
## Summary
- add pipeline request/response schemas
- add pipeline service layer for create/list/get/update with parent-client validation
- add pipeline routes and wire router into app

## Acceptance
- ./.venv/bin/pytest tests/contract/test_clients_pipelines_runs_api.py -k pipelines -q (fails on run endpoints pending T018)
- ./.venv/bin/pytest tests/contract/test_clients_pipelines_runs_api.py::test_pipelines_crud_contract tests/contract/test_clients_pipelines_runs_api.py::test_pipeline_not_found_error_contract -q
