### PR TITLE
CHM T018: Implement runs API including latest run endpoint

### DIFF
--- a/app/api/runs.py
+++ b/app/api/runs.py
@@ -1,0 +1,65 @@
+"""Run API routes."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import Query
+from sqlalchemy.orm import Session
+
+from app.db.base import get_db_session
+from app.db.models.run import RunStatusEnum
+from app.schemas.run import OrderDirection
+from app.schemas.run import Run
+from app.schemas.run import RunCreate
+from app.schemas.run import RunListResponse
+from app.services.runs import create_run_service
+from app.services.runs import get_latest_run_service
+from app.services.runs import list_runs_service
+
+router = APIRouter(prefix="/api/v1", tags=["runs"])
+
+
+@router.post("/pipelines/{pipeline_id}/runs", response_model=Run, status_code=201)
+def create_run_endpoint(
+    pipeline_id: UUID,
+    payload: RunCreate,
+    session: Session = Depends(get_db_session),
+) -> Run:
+    """Create a run for a pipeline."""
+    return create_run_service(session, pipeline_id, payload)
+
+
+@router.get("/pipelines/{pipeline_id}/runs", response_model=RunListResponse)
+def list_runs_endpoint(
+    pipeline_id: UUID,
+    status: RunStatusEnum | None = None,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    limit: int = Query(default=100, ge=1, le=1000),
+    order: OrderDirection = "desc",
+    session: Session = Depends(get_db_session),
+) -> RunListResponse:
+    """List runs for a pipeline."""
+    runs = list_runs_service(
+        session,
+        pipeline_id=pipeline_id,
+        status=status,
+        since=since,
+        until=until,
+        limit=limit,
+        order=order,
+    )
+    return RunListResponse(items=runs)
+
+
+@router.get("/pipelines/{pipeline_id}/runs/latest", response_model=Run)
+def get_latest_run_endpoint(
+    pipeline_id: UUID,
+    session: Session = Depends(get_db_session),
+) -> Run:
+    """Get the latest run for a pipeline."""
+    return get_latest_run_service(session, pipeline_id)

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 
 from app.api.clients import router as clients_router
 from app.api.pipelines import router as pipelines_router
+from app.api.runs import router as runs_router
 from app.core.errors import register_error_handlers
 from app.db import models as _models  # noqa: F401
 
@@ -11,6 +12,7 @@ app = FastAPI(title="CHM")
 register_error_handlers(app)
 app.include_router(clients_router)
 app.include_router(pipelines_router)
+app.include_router(runs_router)
 
 
 @app.get("/health")

--- a/app/schemas/run.py
+++ b/app/schemas/run.py
@@ -1,0 +1,56 @@
+"""Pydantic schemas for run API payloads."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+
+from app.db.models.run import RunStatusEnum
+
+OrderDirection = Literal["desc", "asc"]
+
+
+class RunCreate(BaseModel):
+    """Payload to create a manual run event."""
+
+    external_run_id: str | None = None
+    status: RunStatusEnum
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    duration_seconds: int | None = None
+    rows_processed: int | None = None
+    error_message: str | None = None
+    status_reason: str | None = None
+    payload: dict[str, Any] | None = None
+
+
+class Run(BaseModel):
+    """Run response payload."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    pipeline_id: UUID
+    external_run_id: str
+    status: RunStatusEnum
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    duration_seconds: int | None = None
+    rows_processed: int | None = None
+    error_message: str | None = None
+    status_reason: str | None = None
+    payload: dict[str, Any] | None = None
+    ingested_at: datetime
+    created_at: datetime
+    updated_at: datetime
+
+
+class RunListResponse(BaseModel):
+    """List response envelope for runs."""
+
+    items: list[Run]

--- a/app/services/runs.py
+++ b/app/services/runs.py
@@ -1,0 +1,92 @@
+"""Service helpers for run API operations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+from uuid import uuid4
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.errors import APIError
+from app.core.errors import NotFoundError
+from app.db.repository.pipelines import get_pipeline
+from app.db.repository.runs import create_run
+from app.db.repository.runs import get_latest_run_for_pipeline
+from app.db.repository.runs import list_runs
+from app.schemas.error import ErrorDetail
+from app.schemas.run import OrderDirection
+from app.schemas.run import RunCreate
+from app.db.models.run import RunStatusEnum
+
+
+def _raise_validation_error(message: str, *, field: str = "request") -> None:
+    raise APIError(
+        status_code=400,
+        code="validation_error",
+        message=message,
+        details=[ErrorDetail(field=field, issue=message)],
+    )
+
+
+def _ensure_pipeline_exists(session: Session, pipeline_id: UUID) -> None:
+    if get_pipeline(session, pipeline_id) is None:
+        raise NotFoundError(message="Pipeline not found")
+
+
+def create_run_service(session: Session, pipeline_id: UUID, payload: RunCreate):
+    """Create and persist a run for a pipeline."""
+    _ensure_pipeline_exists(session, pipeline_id)
+    external_run_id = payload.external_run_id or f"manual-{uuid4()}"
+    try:
+        run = create_run(
+            session,
+            pipeline_id=pipeline_id,
+            external_run_id=external_run_id,
+            status=payload.status,
+            started_at=payload.started_at,
+            finished_at=payload.finished_at,
+            duration_seconds=payload.duration_seconds,
+            rows_processed=payload.rows_processed,
+            error_message=payload.error_message,
+            status_reason=payload.status_reason,
+            payload=payload.payload,
+        )
+        session.commit()
+        return run
+    except IntegrityError:
+        session.rollback()
+        _raise_validation_error("Run payload violates schema constraints")
+
+
+def list_runs_service(
+    session: Session,
+    *,
+    pipeline_id: UUID,
+    status: RunStatusEnum | None = None,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    limit: int = 100,
+    order: OrderDirection = "desc",
+):
+    """List runs for a pipeline with filter options."""
+    _ensure_pipeline_exists(session, pipeline_id)
+    return list_runs(
+        session,
+        pipeline_id=pipeline_id,
+        status=status,
+        since=since,
+        until=until,
+        limit=limit,
+        order=order,
+    )
+
+
+def get_latest_run_service(session: Session, pipeline_id: UUID):
+    """Get latest run for a pipeline with deterministic ordering."""
+    _ensure_pipeline_exists(session, pipeline_id)
+    run = get_latest_run_for_pipeline(session, pipeline_id=pipeline_id)
+    if run is None:
+        raise NotFoundError(message="Run not found")
+    return run


### PR DESCRIPTION
## Summary
- add run request/response schemas
- add run service layer for create/list/latest workflows
- add run routes and wire router into app

## Acceptance
- ./.venv/bin/pytest tests/contract/test_clients_pipelines_runs_api.py -k runs -q
