### PR TITLE
CHM T023: Implement partner ingestion HTTP client resilience

### DIFF
--- a/app/ingestion/__init__.py
+++ b/app/ingestion/__init__.py
@@ -1,0 +1,2 @@
+"""Ingestion package for partner synchronization workflows."""
+

--- a/app/ingestion/client.py
+++ b/app/ingestion/client.py
@@ -1,0 +1,179 @@
+"""HTTP client for partner run ingestion with bounded resilience controls."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from collections.abc import Mapping
+from typing import Any
+from urllib.parse import quote
+
+import random
+import time
+
+import requests
+
+RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
+
+class PartnerIngestionClientError(RuntimeError):
+    """Base error raised by partner ingestion client operations."""
+
+
+class PartnerIngestionRequestError(PartnerIngestionClientError):
+    """Raised when partner requests fail after retry budget is exhausted."""
+
+
+class PartnerIngestionResponseError(PartnerIngestionClientError):
+    """Raised when partner responses are malformed."""
+
+
+class PartnerIngestionClient:
+    """Fetch paginated run pages from a partner API with retry/backoff behavior."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_token: str,
+        timeout_seconds: float = 10.0,
+        max_retries: int = 3,
+        backoff_seconds: float = 1.0,
+        session: requests.Session | None = None,
+        sleep_fn: Callable[[float], None] = time.sleep,
+        jitter_fn: Callable[[], float] = random.random,
+    ) -> None:
+        normalized = base_url.rstrip("/")
+        if not normalized:
+            raise ValueError("base_url is required")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        if max_retries < 0:
+            raise ValueError("max_retries must be >= 0")
+        if backoff_seconds <= 0:
+            raise ValueError("backoff_seconds must be positive")
+
+        self._base_url = normalized
+        self._api_token = api_token
+        self._timeout_seconds = timeout_seconds
+        self._max_retries = max_retries
+        self._backoff_seconds = backoff_seconds
+        self._session = session or requests.Session()
+        self._sleep_fn = sleep_fn
+        self._jitter_fn = jitter_fn
+
+    def fetch_runs(
+        self,
+        pipeline_external_id: str,
+        cursor: str | None = None,
+    ) -> dict[str, Any]:
+        """Fetch one page of run events for a pipeline external identifier."""
+        return self._request_page(pipeline_external_id=pipeline_external_id, cursor=cursor)
+
+    def list_runs(
+        self,
+        pipeline_external_id: str,
+        cursor: str | None = None,
+    ) -> dict[str, Any]:
+        """Alias for compatibility with ingestion orchestration call sites."""
+        return self.fetch_runs(pipeline_external_id=pipeline_external_id, cursor=cursor)
+
+    def fetch_pipeline_runs(
+        self,
+        pipeline_external_id: str,
+        cursor: str | None = None,
+    ) -> dict[str, Any]:
+        """Alias for compatibility with ingestion orchestration call sites."""
+        return self.fetch_runs(pipeline_external_id=pipeline_external_id, cursor=cursor)
+
+    def _request_page(
+        self,
+        *,
+        pipeline_external_id: str,
+        cursor: str | None,
+    ) -> dict[str, Any]:
+        if not pipeline_external_id:
+            raise ValueError("pipeline_external_id is required")
+
+        endpoint = quote(pipeline_external_id, safe="")
+        url = f"{self._base_url}/pipelines/{endpoint}/runs"
+        params = {"cursor": cursor} if cursor else None
+
+        for attempt in range(self._max_retries + 1):
+            try:
+                response = self._session.get(
+                    url,
+                    headers=self._headers(),
+                    params=params,
+                    timeout=self._timeout_seconds,
+                )
+            except (requests.Timeout, requests.ConnectionError) as exc:
+                if attempt >= self._max_retries:
+                    raise PartnerIngestionRequestError(
+                        "Partner request failed after retry budget was exhausted",
+                    ) from exc
+                self._sleep_fn(self._retry_delay(attempt))
+                continue
+            except requests.RequestException as exc:
+                raise PartnerIngestionRequestError("Partner request failed") from exc
+
+            if response.status_code in RETRYABLE_STATUS_CODES:
+                if attempt >= self._max_retries:
+                    raise PartnerIngestionRequestError(
+                        f"Partner request failed with retryable status {response.status_code}",
+                    )
+                self._sleep_fn(self._retry_delay(attempt, response.headers))
+                continue
+
+            try:
+                response.raise_for_status()
+            except requests.HTTPError as exc:
+                raise PartnerIngestionRequestError(
+                    f"Partner request failed with status {response.status_code}",
+                ) from exc
+
+            return self._normalize_page(response.json())
+
+        raise PartnerIngestionRequestError("Partner request failed")
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._api_token}",
+            "Accept": "application/json",
+            "User-Agent": "chm-ingestion/0.1",
+        }
+
+    def _retry_delay(
+        self,
+        attempt: int,
+        headers: Mapping[str, Any] | None = None,
+    ) -> float:
+        base = self._backoff_seconds * (2**attempt)
+        jitter = self._jitter_fn() * self._backoff_seconds
+        delay = base + jitter
+
+        if headers:
+            retry_after = headers.get("Retry-After")
+            if retry_after is not None:
+                try:
+                    delay = max(delay, float(retry_after))
+                except (TypeError, ValueError):
+                    pass
+        return delay
+
+    @staticmethod
+    def _normalize_page(raw: Any) -> dict[str, Any]:
+        if not isinstance(raw, dict):
+            raise PartnerIngestionResponseError("Partner payload must be a JSON object")
+
+        runs = raw.get("runs", [])
+        if runs is None:
+            runs = []
+        if not isinstance(runs, list):
+            raise PartnerIngestionResponseError("Partner payload field `runs` must be a list")
+
+        next_cursor = raw.get("next_cursor")
+        return {
+            "runs": runs,
+            "next_cursor": None if next_cursor is None else str(next_cursor),
+        }
+

--- a/tests/unit/test_ingestion_client.py
+++ b/tests/unit/test_ingestion_client.py
@@ -1,0 +1,151 @@
+"""Unit tests for partner ingestion HTTP client resilience behavior."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+import requests
+
+from app.ingestion.client import PartnerIngestionClient
+from app.ingestion.client import PartnerIngestionRequestError
+from app.ingestion.client import PartnerIngestionResponseError
+
+
+@dataclass
+class _FakeResponse:
+    status_code: int
+    body: Any
+    headers: dict[str, str] | None = None
+
+    def json(self) -> Any:
+        return self.body
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            response = requests.Response()
+            response.status_code = self.status_code
+            raise requests.HTTPError(response=response)
+
+
+class _SessionStub:
+    def __init__(self, request_fn: Callable[..., _FakeResponse]) -> None:
+        self._request_fn = request_fn
+        self.calls: list[dict[str, Any]] = []
+
+    def get(self, url: str, *, headers: dict[str, str], params: dict[str, Any] | None, timeout: float):
+        self.calls.append(
+            {
+                "url": url,
+                "headers": headers,
+                "params": params,
+                "timeout": timeout,
+            }
+        )
+        return self._request_fn(url=url, headers=headers, params=params, timeout=timeout)
+
+
+def test_fetch_runs_retries_retryable_statuses_and_succeeds() -> None:
+    responses = [
+        _FakeResponse(429, {"runs": []}, headers={"Retry-After": "2"}),
+        _FakeResponse(500, {"runs": []}),
+        _FakeResponse(200, {"runs": [{"id": "run-1"}], "next_cursor": "cursor-2"}),
+    ]
+
+    def request_fn(**_: Any) -> _FakeResponse:
+        return responses.pop(0)
+
+    session = _SessionStub(request_fn)
+    sleep_delays: list[float] = []
+    client = PartnerIngestionClient(
+        base_url="https://partner.example.com",
+        api_token="top-secret-token",
+        timeout_seconds=4.0,
+        max_retries=3,
+        backoff_seconds=1.0,
+        session=session,  # type: ignore[arg-type]
+        sleep_fn=sleep_delays.append,
+        jitter_fn=lambda: 0.0,
+    )
+
+    page = client.fetch_runs("vendor-pipeline-01")
+
+    assert page == {"runs": [{"id": "run-1"}], "next_cursor": "cursor-2"}
+    assert len(session.calls) == 3
+    assert session.calls[0]["timeout"] == 4.0
+    assert session.calls[0]["headers"]["Authorization"] == "Bearer top-secret-token"
+    assert sleep_delays == [2.0, 2.0]
+
+
+def test_fetch_runs_retries_connection_errors_until_budget_exhausted() -> None:
+    attempts = {"count": 0}
+
+    def request_fn(**_: Any) -> _FakeResponse:
+        attempts["count"] += 1
+        raise requests.ConnectionError("temporary network issue")
+
+    session = _SessionStub(request_fn)
+    sleep_delays: list[float] = []
+    client = PartnerIngestionClient(
+        base_url="https://partner.example.com",
+        api_token="token",
+        timeout_seconds=2.0,
+        max_retries=2,
+        backoff_seconds=1.0,
+        session=session,  # type: ignore[arg-type]
+        sleep_fn=sleep_delays.append,
+        jitter_fn=lambda: 0.0,
+    )
+
+    with pytest.raises(PartnerIngestionRequestError):
+        client.fetch_runs("vendor-pipeline-01")
+
+    assert attempts["count"] == 3
+    assert sleep_delays == [1.0, 2.0]
+
+
+def test_fetch_runs_does_not_retry_non_retryable_http_errors() -> None:
+    responses = [_FakeResponse(400, {"error": "bad request"})]
+
+    def request_fn(**_: Any) -> _FakeResponse:
+        return responses.pop(0)
+
+    session = _SessionStub(request_fn)
+    sleep_delays: list[float] = []
+    client = PartnerIngestionClient(
+        base_url="https://partner.example.com",
+        api_token="token",
+        max_retries=3,
+        backoff_seconds=1.0,
+        session=session,  # type: ignore[arg-type]
+        sleep_fn=sleep_delays.append,
+        jitter_fn=lambda: 0.0,
+    )
+
+    with pytest.raises(PartnerIngestionRequestError):
+        client.fetch_runs("vendor-pipeline-01")
+
+    assert len(session.calls) == 1
+    assert sleep_delays == []
+
+
+def test_fetch_runs_rejects_malformed_payload() -> None:
+    responses = [_FakeResponse(200, {"runs": "not-a-list"})]
+
+    def request_fn(**_: Any) -> _FakeResponse:
+        return responses.pop(0)
+
+    session = _SessionStub(request_fn)
+    client = PartnerIngestionClient(
+        base_url="https://partner.example.com",
+        api_token="token",
+        session=session,  # type: ignore[arg-type]
+        sleep_fn=lambda _: None,
+        jitter_fn=lambda: 0.0,
+    )
+
+    with pytest.raises(PartnerIngestionResponseError):
+        client.fetch_runs("vendor-pipeline-01")
+


### PR DESCRIPTION
## Summary
- add resilient partner ingestion HTTP client in `app/ingestion/client.py`
- implement timeout, bounded retry, exponential backoff, and retryable 429/5xx handling
- add deterministic unit coverage for retry/non-retry/malformed-payload cases

## Task Link
Closes #29

## Acceptance
- `./.venv/bin/pytest tests/unit/test_ingestion_client.py -q`

## Checklist
- [x] This PR implements exactly one primary task
- [x] Base branch is `main`
- [x] Acceptance check command(s) executed locally
- [x] No requirements added beyond spec/contracts
