### PR TITLE
CHM T027: Wire ingestion execution endpoint and secure logging

### DIFF
--- a/app/api/ingestion.py
+++ b/app/api/ingestion.py
@@ -1,0 +1,57 @@
+"""Operational ingestion trigger routes."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter
+from fastapi import Depends
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.core.config import IngestionSettings
+from app.core.config import get_ingestion_settings
+from app.db.base import get_db_session
+from app.ingestion.client import PartnerIngestionClient
+from app.ingestion.job import ingest_external_runs
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1", tags=["ingestion"])
+
+
+class IngestionSyncResponse(BaseModel):
+    """Response payload for ingestion trigger runs."""
+
+    pipelines_processed: int
+    pages_processed: int
+    runs_processed: int
+
+
+@router.post("/ingestion/runs/sync", response_model=IngestionSyncResponse)
+def trigger_ingestion_sync(
+    session: Session = Depends(get_db_session),
+    settings: IngestionSettings = Depends(get_ingestion_settings),
+) -> IngestionSyncResponse:
+    """Trigger partner ingestion and persist normalized run events."""
+    logger.info("Starting ingestion sync with settings=%s", settings.safe_for_logging())
+
+    partner_client = PartnerIngestionClient(
+        base_url=settings.partner_api_base_url,
+        api_token=settings.partner_api_token,
+        timeout_seconds=settings.http_timeout_seconds,
+        max_retries=settings.http_max_retries,
+        backoff_seconds=settings.http_backoff_seconds,
+    )
+
+    try:
+        result = ingest_external_runs(session=session, partner_client=partner_client)
+        session.commit()
+    except Exception:
+        session.rollback()
+        logger.exception("Ingestion sync failed")
+        raise
+
+    logger.info("Completed ingestion sync with result=%s", result)
+    return IngestionSyncResponse(**result)
+

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,0 +1,67 @@
+"""Application configuration helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+import os
+
+DEFAULT_PARTNER_API_BASE_URL = "https://partner.example.com"
+DEFAULT_HTTP_TIMEOUT_SECONDS = 10.0
+DEFAULT_HTTP_MAX_RETRIES = 3
+DEFAULT_HTTP_BACKOFF_SECONDS = 1.0
+
+
+def _get_float_env(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return float(raw)
+
+
+def _get_int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return int(raw)
+
+
+def redact_secret(secret: str) -> str:
+    """Return a non-recoverable placeholder for sensitive values."""
+    if not secret:
+        return "<empty>"
+    return "<redacted>"
+
+
+@dataclass(frozen=True)
+class IngestionSettings:
+    """Runtime settings for partner ingestion calls."""
+
+    partner_api_base_url: str
+    partner_api_token: str
+    http_timeout_seconds: float
+    http_max_retries: int
+    http_backoff_seconds: float
+
+    def safe_for_logging(self) -> dict[str, str | int | float]:
+        """Return ingestion settings safe for logs."""
+        return {
+            "partner_api_base_url": self.partner_api_base_url,
+            "partner_api_token": redact_secret(self.partner_api_token),
+            "http_timeout_seconds": self.http_timeout_seconds,
+            "http_max_retries": self.http_max_retries,
+            "http_backoff_seconds": self.http_backoff_seconds,
+        }
+
+
+@lru_cache(maxsize=1)
+def get_ingestion_settings() -> IngestionSettings:
+    """Load ingestion settings from the environment."""
+    return IngestionSettings(
+        partner_api_base_url=os.getenv("CHM_PARTNER_API_BASE_URL", DEFAULT_PARTNER_API_BASE_URL),
+        partner_api_token=os.getenv("CHM_PARTNER_API_TOKEN", ""),
+        http_timeout_seconds=_get_float_env("CHM_HTTP_TIMEOUT_SECONDS", DEFAULT_HTTP_TIMEOUT_SECONDS),
+        http_max_retries=_get_int_env("CHM_HTTP_MAX_RETRIES", DEFAULT_HTTP_MAX_RETRIES),
+        http_backoff_seconds=_get_float_env("CHM_HTTP_BACKOFF_SECONDS", DEFAULT_HTTP_BACKOFF_SECONDS),
+    )
+

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@
 from fastapi import FastAPI
 
 from app.api.clients import router as clients_router
+from app.api.ingestion import router as ingestion_router
 from app.api.pipelines import router as pipelines_router
 from app.api.runs import router as runs_router
 from app.core.errors import register_error_handlers
@@ -13,6 +14,7 @@ register_error_handlers(app)
 app.include_router(clients_router)
 app.include_router(pipelines_router)
 app.include_router(runs_router)
+app.include_router(ingestion_router)
 
 
 @app.get("/health")


### PR DESCRIPTION
## Summary
- add ingestion runtime config in `app/core/config.py`
- add ingestion trigger endpoint in `app/api/ingestion.py` and wire router in `app/main.py`
- use redacted config logging to prevent token leakage in ingestion execution logs
- add integration assertion in `tests/integration/test_ingestion_idempotency.py` for secret-safe logging behavior

## Task Link
Closes #33

## Acceptance
- `./.venv/bin/pytest tests/integration/test_ingestion_idempotency.py -k logging -q`

## Additional Validation
- `./.venv/bin/pytest tests/integration/test_ingestion_idempotency.py tests/integration/test_ingestion_progression_and_pagination.py -q`

## Checklist
- [x] This PR implements exactly one primary task
- [x] Base branch is `main`
- [x] Acceptance check command(s) executed locally
- [x] No requirements added beyond spec/contracts
