### PR TITLE
CHM T028: Add alert rules contract and validation tests

### DIFF
--- a/tests/contract/test_alert_rules_api.py
+++ b/tests/contract/test_alert_rules_api.py
@@ -68,7 +68,8 @@ def _assert_alert_rule_contract(payload: dict) -> None:
 
 
 def _create_client(test_client: TestClient, name: str) -> dict:
-    response = test_client.post(f"{API_PREFIX}/clients", json={"name": name})
+    unique_name = f"{name}-{uuid.uuid4().hex[:8]}"
+    response = test_client.post(f"{API_PREFIX}/clients", json={"name": unique_name})
     assert response.status_code == 201
     return response.json()
 
@@ -187,4 +188,3 @@ def test_alert_rule_validation_contract_on_failure_allows_empty_threshold_and_wi
     _assert_alert_rule_contract(payload)
     assert payload["threshold"] is None
     assert payload["window_minutes"] is None
-


### PR DESCRIPTION
## Summary
Add alert-rule contract tests that lock CRUD behavior and rule-type validation requirements.

## Task Link
Closes #39

## Checklist
- [x] This PR implements exactly one primary task
- [x] Base branch is `main`
- [x] Acceptance check command(s) executed locally
- [x] No requirements added beyond spec/contracts

## Acceptance Check
- `.venv/bin/pytest tests/contract/test_alert_rules_api.py`
- Result: fails as expected in test-first mode because `/api/v1/alert_rules` endpoints are not implemented yet (T031).
