### PR TITLE
CHM T031: Implement alert rules API parity

### DIFF
--- a/app/api/alert_rules.py
+++ b/app/api/alert_rules.py
@@ -1,0 +1,78 @@
+"""Alert-rule API routes."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import Response
+from sqlalchemy.orm import Session
+
+from app.db.base import get_db_session
+from app.schemas.alert_rule import AlertRule
+from app.schemas.alert_rule import AlertRuleCreate
+from app.schemas.alert_rule import AlertRuleListResponse
+from app.schemas.alert_rule import AlertRuleUpdate
+from app.services.alert_rules import create_alert_rule_service
+from app.services.alert_rules import delete_alert_rule_service
+from app.services.alert_rules import get_alert_rule_service
+from app.services.alert_rules import list_alert_rules_service
+from app.services.alert_rules import update_alert_rule_service
+
+router = APIRouter(prefix="/api/v1", tags=["alert_rules"])
+
+
+@router.post("/alert_rules", response_model=AlertRule, status_code=201)
+def create_alert_rule_endpoint(
+    payload: AlertRuleCreate,
+    session: Session = Depends(get_db_session),
+) -> AlertRule:
+    """Create an alert rule."""
+    return create_alert_rule_service(session, payload)
+
+
+@router.get("/alert_rules", response_model=AlertRuleListResponse)
+def list_alert_rules_endpoint(
+    client_id: UUID | None = None,
+    pipeline_id: UUID | None = None,
+    is_enabled: bool | None = None,
+    session: Session = Depends(get_db_session),
+) -> AlertRuleListResponse:
+    """List alert rules with optional filters."""
+    items = list_alert_rules_service(
+        session,
+        client_id=client_id,
+        pipeline_id=pipeline_id,
+        is_enabled=is_enabled,
+    )
+    return AlertRuleListResponse(items=items)
+
+
+@router.get("/alert_rules/{rule_id}", response_model=AlertRule)
+def get_alert_rule_endpoint(
+    rule_id: UUID,
+    session: Session = Depends(get_db_session),
+) -> AlertRule:
+    """Get an alert rule by id."""
+    return get_alert_rule_service(session, rule_id)
+
+
+@router.patch("/alert_rules/{rule_id}", response_model=AlertRule)
+def update_alert_rule_endpoint(
+    rule_id: UUID,
+    payload: AlertRuleUpdate,
+    session: Session = Depends(get_db_session),
+) -> AlertRule:
+    """Update an alert rule."""
+    return update_alert_rule_service(session, rule_id, payload)
+
+
+@router.delete("/alert_rules/{rule_id}", status_code=204)
+def delete_alert_rule_endpoint(
+    rule_id: UUID,
+    session: Session = Depends(get_db_session),
+) -> Response:
+    """Delete an alert rule by id."""
+    delete_alert_rule_service(session, rule_id)
+    return Response(status_code=204)

--- a/app/db/repository/alert_rules.py
+++ b/app/db/repository/alert_rules.py
@@ -11,6 +11,8 @@ from app.db.models.alert_rule import AlertRule
 from app.db.models.alert_rule import ChannelEnum
 from app.db.models.alert_rule import RuleTypeEnum
 
+UNSET = object()
+
 
 def create_alert_rule(
     session: Session,
@@ -60,10 +62,12 @@ def list_alert_rules(
 ) -> list[AlertRule]:
     """List alert rules with optional scope/enablement filters."""
     stmt = select(AlertRule)
-    if client_id is not None:
-        stmt = stmt.where(AlertRule.client_id == client_id)
     if pipeline_id is not None:
         stmt = stmt.where(AlertRule.pipeline_id == pipeline_id)
+    elif client_id is not None:
+        # Pipeline-scoped rules take precedence and should not be returned
+        # in a client-only scoped list.
+        stmt = stmt.where(AlertRule.client_id == client_id).where(AlertRule.pipeline_id.is_(None))
     if is_enabled is not None:
         stmt = stmt.where(AlertRule.is_enabled == is_enabled)
     stmt = stmt.order_by(AlertRule.created_at.desc()).limit(limit).offset(offset)
@@ -74,33 +78,33 @@ def update_alert_rule(
     session: Session,
     alert_rule: AlertRule,
     *,
-    rule_type: RuleTypeEnum | None = None,
-    channel: ChannelEnum | None = None,
-    destination: str | None = None,
-    client_id: UUID | None = None,
-    pipeline_id: UUID | None = None,
-    threshold: int | None = None,
-    window_minutes: int | None = None,
-    is_enabled: bool | None = None,
+    rule_type: RuleTypeEnum | None | object = UNSET,
+    channel: ChannelEnum | None | object = UNSET,
+    destination: str | None | object = UNSET,
+    client_id: UUID | None | object = UNSET,
+    pipeline_id: UUID | None | object = UNSET,
+    threshold: int | None | object = UNSET,
+    window_minutes: int | None | object = UNSET,
+    is_enabled: bool | None | object = UNSET,
 ) -> AlertRule:
     """Update mutable alert-rule fields."""
-    if rule_type is not None:
+    if rule_type is not UNSET:
         alert_rule.rule_type = (
             rule_type.value if isinstance(rule_type, RuleTypeEnum) else rule_type
         )
-    if channel is not None:
+    if channel is not UNSET:
         alert_rule.channel = channel.value if isinstance(channel, ChannelEnum) else channel
-    if destination is not None:
+    if destination is not UNSET:
         alert_rule.destination = destination
-    if client_id is not None:
+    if client_id is not UNSET:
         alert_rule.client_id = client_id
-    if pipeline_id is not None:
+    if pipeline_id is not UNSET:
         alert_rule.pipeline_id = pipeline_id
-    if threshold is not None:
+    if threshold is not UNSET:
         alert_rule.threshold = threshold
-    if window_minutes is not None:
+    if window_minutes is not UNSET:
         alert_rule.window_minutes = window_minutes
-    if is_enabled is not None:
+    if is_enabled is not UNSET:
         alert_rule.is_enabled = is_enabled
 
     session.flush()

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@
 
 from fastapi import FastAPI
 
+from app.api.alert_rules import router as alert_rules_router
 from app.api.clients import router as clients_router
 from app.api.ingestion import router as ingestion_router
 from app.api.pipelines import router as pipelines_router
@@ -11,6 +12,7 @@ from app.db import models as _models  # noqa: F401
 
 app = FastAPI(title="CHM")
 register_error_handlers(app)
+app.include_router(alert_rules_router)
 app.include_router(clients_router)
 app.include_router(pipelines_router)
 app.include_router(runs_router)

--- a/app/schemas/alert_rule.py
+++ b/app/schemas/alert_rule.py
@@ -1,0 +1,62 @@
+"""Pydantic schemas for alert-rule API payloads."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+
+from app.db.models.alert_rule import ChannelEnum
+from app.db.models.alert_rule import RuleTypeEnum
+
+
+class AlertRuleCreate(BaseModel):
+    """Payload to create an alert rule."""
+
+    client_id: UUID | None = None
+    pipeline_id: UUID | None = None
+    rule_type: RuleTypeEnum
+    threshold: int | None = None
+    window_minutes: int | None = None
+    channel: ChannelEnum
+    destination: str
+    is_enabled: bool = True
+
+
+class AlertRuleUpdate(BaseModel):
+    """Payload to update mutable alert rule fields."""
+
+    client_id: UUID | None = None
+    pipeline_id: UUID | None = None
+    rule_type: RuleTypeEnum | None = None
+    threshold: int | None = None
+    window_minutes: int | None = None
+    channel: ChannelEnum | None = None
+    destination: str | None = None
+    is_enabled: bool | None = None
+
+
+class AlertRule(BaseModel):
+    """Alert-rule response payload."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    client_id: UUID | None = None
+    pipeline_id: UUID | None = None
+    rule_type: RuleTypeEnum
+    threshold: int | None = None
+    window_minutes: int | None = None
+    channel: ChannelEnum
+    destination: str
+    is_enabled: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class AlertRuleListResponse(BaseModel):
+    """List response envelope for alert rules."""
+
+    items: list[AlertRule]

--- a/app/services/alert_rules.py
+++ b/app/services/alert_rules.py
@@ -1,0 +1,158 @@
+"""Service helpers for alert-rule API operations."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.errors import APIError
+from app.core.errors import NotFoundError
+from app.db.models.alert_rule import RuleTypeEnum
+from app.db.repository.alert_rules import UNSET
+from app.db.repository.alert_rules import create_alert_rule
+from app.db.repository.alert_rules import delete_alert_rule
+from app.db.repository.alert_rules import get_alert_rule
+from app.db.repository.alert_rules import list_alert_rules
+from app.db.repository.alert_rules import update_alert_rule
+from app.schemas.alert_rule import AlertRuleCreate
+from app.schemas.alert_rule import AlertRuleUpdate
+from app.schemas.error import ErrorDetail
+
+
+def _raise_validation_error(message: str, *, field: str = "request") -> None:
+    raise APIError(
+        status_code=400,
+        code="validation_error",
+        message=message,
+        details=[ErrorDetail(field=field, issue=message)],
+    )
+
+
+def _validate_scope(client_id: UUID | None, pipeline_id: UUID | None) -> None:
+    if client_id is None and pipeline_id is None:
+        _raise_validation_error(
+            "At least one scope must be set (client_id or pipeline_id)",
+            field="client_id",
+        )
+
+
+def _validate_rule_params(
+    *,
+    rule_type: RuleTypeEnum,
+    threshold: int | None,
+    window_minutes: int | None,
+) -> None:
+    if threshold is not None and threshold <= 0:
+        _raise_validation_error("threshold must be greater than 0", field="threshold")
+    if window_minutes is not None and window_minutes <= 0:
+        _raise_validation_error("window_minutes must be greater than 0", field="window_minutes")
+    if rule_type == RuleTypeEnum.FAILURES_IN_WINDOW and (
+        threshold is None or window_minutes is None
+    ):
+        _raise_validation_error(
+            "failures_in_window requires threshold and window_minutes",
+            field="rule_type",
+        )
+
+
+def create_alert_rule_service(session: Session, payload: AlertRuleCreate):
+    """Create and persist a new alert rule."""
+    _validate_scope(payload.client_id, payload.pipeline_id)
+    _validate_rule_params(
+        rule_type=payload.rule_type,
+        threshold=payload.threshold,
+        window_minutes=payload.window_minutes,
+    )
+    try:
+        alert_rule = create_alert_rule(
+            session,
+            client_id=payload.client_id,
+            pipeline_id=payload.pipeline_id,
+            rule_type=payload.rule_type,
+            threshold=payload.threshold,
+            window_minutes=payload.window_minutes,
+            channel=payload.channel,
+            destination=payload.destination,
+            is_enabled=payload.is_enabled,
+        )
+        session.commit()
+        return alert_rule
+    except IntegrityError:
+        session.rollback()
+        _raise_validation_error("Alert rule payload violates schema constraints")
+
+
+def list_alert_rules_service(
+    session: Session,
+    *,
+    client_id: UUID | None = None,
+    pipeline_id: UUID | None = None,
+    is_enabled: bool | None = None,
+):
+    """List alert rules with optional scope and enabled filters."""
+    return list_alert_rules(
+        session,
+        client_id=client_id,
+        pipeline_id=pipeline_id,
+        is_enabled=is_enabled,
+    )
+
+
+def get_alert_rule_service(session: Session, rule_id: UUID):
+    """Fetch an alert rule or raise not found."""
+    alert_rule = get_alert_rule(session, rule_id)
+    if alert_rule is None:
+        raise NotFoundError(message="Alert rule not found")
+    return alert_rule
+
+
+def update_alert_rule_service(session: Session, rule_id: UUID, payload: AlertRuleUpdate):
+    """Update mutable alert-rule fields."""
+    alert_rule = get_alert_rule_service(session, rule_id)
+
+    next_client_id = payload.client_id if "client_id" in payload.model_fields_set else alert_rule.client_id
+    next_pipeline_id = (
+        payload.pipeline_id if "pipeline_id" in payload.model_fields_set else alert_rule.pipeline_id
+    )
+    next_rule_type = payload.rule_type if payload.rule_type is not None else alert_rule.rule_type
+    next_threshold = payload.threshold if "threshold" in payload.model_fields_set else alert_rule.threshold
+    next_window_minutes = (
+        payload.window_minutes
+        if "window_minutes" in payload.model_fields_set
+        else alert_rule.window_minutes
+    )
+
+    _validate_scope(next_client_id, next_pipeline_id)
+    _validate_rule_params(
+        rule_type=next_rule_type,
+        threshold=next_threshold,
+        window_minutes=next_window_minutes,
+    )
+
+    try:
+        alert_rule = update_alert_rule(
+            session,
+            alert_rule,
+            client_id=payload.client_id if "client_id" in payload.model_fields_set else UNSET,
+            pipeline_id=payload.pipeline_id if "pipeline_id" in payload.model_fields_set else UNSET,
+            rule_type=payload.rule_type if "rule_type" in payload.model_fields_set else UNSET,
+            threshold=next_threshold if "threshold" in payload.model_fields_set else UNSET,
+            window_minutes=next_window_minutes if "window_minutes" in payload.model_fields_set else UNSET,
+            channel=payload.channel if "channel" in payload.model_fields_set else UNSET,
+            destination=payload.destination if "destination" in payload.model_fields_set else UNSET,
+            is_enabled=payload.is_enabled if "is_enabled" in payload.model_fields_set else UNSET,
+        )
+        session.commit()
+        return alert_rule
+    except IntegrityError:
+        session.rollback()
+        _raise_validation_error("Alert rule payload violates schema constraints")
+
+
+def delete_alert_rule_service(session: Session, rule_id: UUID) -> None:
+    """Delete an alert rule by id."""
+    alert_rule = get_alert_rule_service(session, rule_id)
+    delete_alert_rule(session, alert_rule)
+    session.commit()


### PR DESCRIPTION
## Summary\n- add alert-rule request/response schemas\n- implement alert-rule service validation and CRUD behavior\n- add alert-rule API router and wire it into the FastAPI app\n- enforce pipeline-scope precedence for client-only alert-rule listing\n\n## Validation\n- .venv/bin/ruff check app/api/alert_rules.py app/schemas/alert_rule.py app/services/alert_rules.py app/db/repository/alert_rules.py app/main.py\n- .venv/bin/pytest -q tests/contract/test_alert_rules_api.py tests/integration/test_alert_rules_scope.py\n\nCloses #45