### PR TITLE
CHM T035: Create and track GitHub issues for all implementation tasks

### DIFF
--- a/docs/project-management/issues.md
+++ b/docs/project-management/issues.md
@@ -1,0 +1,45 @@
+# CHM Task Issues (T001-T034)
+
+This document tracks the one-issue-per-task workflow for `specs/001-chm-api-ingestion` tasks `T001` through `T034`.
+
+| Task | Issue | State | Milestone Label | Assignee |
+|---|---|---|---|---|
+| T001 | [#53](https://github.com/Fatih0234/CHM/issues/53) | CLOSED | `milestone:setup` | `Fatih0234` |
+| T002 | [#54](https://github.com/Fatih0234/CHM/issues/54) | CLOSED | `milestone:setup` | `Fatih0234` |
+| T003 | [#55](https://github.com/Fatih0234/CHM/issues/55) | CLOSED | `milestone:setup` | `Fatih0234` |
+| T004 | [#56](https://github.com/Fatih0234/CHM/issues/56) | CLOSED | `milestone:setup` | `Fatih0234` |
+| T005 | [#57](https://github.com/Fatih0234/CHM/issues/57) | CLOSED | `milestone:setup` | `Fatih0234` |
+| T006 | [#58](https://github.com/Fatih0234/CHM/issues/58) | CLOSED | `milestone:schema-first` | `Fatih0234` |
+| T007 | [#59](https://github.com/Fatih0234/CHM/issues/59) | CLOSED | `milestone:schema-first` | `Fatih0234` |
+| T008 | [#60](https://github.com/Fatih0234/CHM/issues/60) | CLOSED | `milestone:schema-first` | `Fatih0234` |
+| T009 | [#61](https://github.com/Fatih0234/CHM/issues/61) | CLOSED | `milestone:schema-first` | `Fatih0234` |
+| T010 | [#62](https://github.com/Fatih0234/CHM/issues/62) | CLOSED | `milestone:schema-first` | `Fatih0234` |
+| T011 | [#63](https://github.com/Fatih0234/CHM/issues/63) | CLOSED | `milestone:schema-first` | `Fatih0234` |
+| T012 | [#64](https://github.com/Fatih0234/CHM/issues/64) | CLOSED | `milestone:schema-first` | `Fatih0234` |
+| T013 | [#15](https://github.com/Fatih0234/CHM/issues/15) | CLOSED | `milestone:api-baseline` | `Fatih0234` |
+| T014 | [#14](https://github.com/Fatih0234/CHM/issues/14) | CLOSED | `milestone:api-baseline` | `Fatih0234` |
+| T015 | [#18](https://github.com/Fatih0234/CHM/issues/18) | CLOSED | `milestone:api-baseline` | `Fatih0234` |
+| T016 | [#65](https://github.com/Fatih0234/CHM/issues/65) | CLOSED | `milestone:api-baseline` | `Fatih0234` |
+| T017 | [#66](https://github.com/Fatih0234/CHM/issues/66) | CLOSED | `milestone:api-baseline` | `Fatih0234` |
+| T018 | [#67](https://github.com/Fatih0234/CHM/issues/67) | CLOSED | `milestone:api-baseline` | `Fatih0234` |
+| T019 | [#68](https://github.com/Fatih0234/CHM/issues/68) | CLOSED | `milestone:api-baseline` | `Fatih0234` |
+| T020 | [#69](https://github.com/Fatih0234/CHM/issues/69) | CLOSED | `milestone:api-baseline` | `Fatih0234` |
+| T021 | [#25](https://github.com/Fatih0234/CHM/issues/25) | CLOSED | `milestone:ingestion-job` | `Fatih0234` |
+| T022 | [#26](https://github.com/Fatih0234/CHM/issues/26) | CLOSED | `milestone:ingestion-job` | `Fatih0234` |
+| T023 | [#29](https://github.com/Fatih0234/CHM/issues/29) | CLOSED | `milestone:ingestion-job` | `Fatih0234` |
+| T024 | [#30](https://github.com/Fatih0234/CHM/issues/30) | CLOSED | `milestone:ingestion-job` | `Fatih0234` |
+| T025 | [#31](https://github.com/Fatih0234/CHM/issues/31) | CLOSED | `milestone:ingestion-job` | `Fatih0234` |
+| T026 | [#32](https://github.com/Fatih0234/CHM/issues/32) | CLOSED | `milestone:ingestion-job` | `Fatih0234` |
+| T027 | [#33](https://github.com/Fatih0234/CHM/issues/33) | CLOSED | `milestone:ingestion-job` | `Fatih0234` |
+| T028 | [#39](https://github.com/Fatih0234/CHM/issues/39) | CLOSED | `milestone:test-coverage-gate` | `Fatih0234` |
+| T029 | [#41](https://github.com/Fatih0234/CHM/issues/41) | CLOSED | `milestone:test-coverage-gate` | `Fatih0234` |
+| T030 | [#43](https://github.com/Fatih0234/CHM/issues/43) | CLOSED | `milestone:test-coverage-gate` | `Fatih0234` |
+| T031 | [#45](https://github.com/Fatih0234/CHM/issues/45) | CLOSED | `milestone:dashboard-query-shapes` | `Fatih0234` |
+| T032 | [#46](https://github.com/Fatih0234/CHM/issues/46) | CLOSED | `milestone:dashboard-query-shapes` | `Fatih0234` |
+| T033 | [#47](https://github.com/Fatih0234/CHM/issues/47) | CLOSED | `milestone:dashboard-query-shapes` | `Fatih0234` |
+| T034 | [#48](https://github.com/Fatih0234/CHM/issues/48) | CLOSED | `milestone:dashboard-query-shapes` | `Fatih0234` |
+
+## Validation
+
+- Command: `gh issue list --repo Fatih0234/CHM --limit 200 --state all`
+- Result: all tasks `T001`-`T034` have corresponding issues with milestone label, assignee, and closed/open state tracked above.


### PR DESCRIPTION
## Summary
Backfill and normalize task tracking issues for `T001`-`T034`, then record issue URLs and status in `docs/project-management/issues.md`.

## Task Link
Closes #70

## Checklist
- [x] This PR implements exactly one primary task
- [x] Base branch is `main`
- [x] Acceptance check command(s) executed locally
- [x] No requirements added beyond spec/contracts

## Acceptance Evidence
- `gh issue list --repo Fatih0234/CHM --limit 200 --state all`
