### PR TITLE
CHM T036: Enforce issue-linked PR workflow targeting main

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,10 +2,15 @@
 Describe the single task implemented in this PR.
 
 ## Task Link
+Required format (exact keyword for auto-close):
 Closes #<issue-number>
+
+## Base Branch Check
+This PR must target base branch `main`.
 
 ## Checklist
 - [ ] This PR implements exactly one primary task
 - [ ] Base branch is `main`
+- [ ] PR body includes `Closes #<issue-number>`
 - [ ] Acceptance check command(s) executed locally
 - [ ] No requirements added beyond spec/contracts

--- a/docs/project-management/pr-workflow.md
+++ b/docs/project-management/pr-workflow.md
@@ -1,0 +1,32 @@
+# CHM Pull Request Workflow
+
+Use one issue and one PR per SpecKit task.
+
+## Required Rules
+
+- Every task must have one GitHub issue.
+- Every task branch must start from `main` and target `main`.
+- Every PR must include `Closes #<issue-number>` in the body.
+- Every PR must implement one primary task only.
+
+## Task-Scoped Flow
+
+1. Create or confirm the task issue (`CHM T###: ...`).
+2. Sync local `main`:
+   - `git checkout main`
+   - `git pull --ff-only origin main`
+3. Create a task branch:
+   - `git checkout -b codex/task/T###-short-slug`
+4. Implement the task and run acceptance checks from `tasks.md`.
+5. Commit with `CHM T###: <task title>`.
+6. Push branch:
+   - `git push -u origin codex/task/T###-short-slug`
+7. Create PR with base branch `main` and include:
+   - `Closes #<issue-number>`
+8. Merge PR after checks pass, then sync local `main` again.
+
+## Verification
+
+- Confirm PR body includes `Closes #<issue-number>`.
+- Confirm PR base branch is `main`.
+- Confirm related issue auto-closes after merge.


### PR DESCRIPTION
## Summary
Add `docs/project-management/pr-workflow.md` with the task-scoped branch/PR/merge process and update the PR template to explicitly require issue-closing syntax and base branch `main`.

## Task Link
Closes #72

## Checklist
- [x] This PR implements exactly one primary task
- [x] Base branch is `main`
- [x] PR body includes `Closes #<issue-number>`
- [x] Acceptance check command(s) executed locally
- [x] No requirements added beyond spec/contracts

## Acceptance Evidence
- `rg -n "Closes #|base branch.*main" docs/project-management/pr-workflow.md .github/pull_request_template.md`
